### PR TITLE
feat: add GDPR consent management module

### DIFF
--- a/docs/explanation/gdpr-consent-design.md
+++ b/docs/explanation/gdpr-consent-design.md
@@ -1,0 +1,91 @@
+# GDPR Consent Management Design
+
+## The problem
+
+European privacy regulations (GDPR, ePrivacy) require websites to obtain user consent before loading non-essential tracking scripts. Most WordPress solutions rely on heavyweight plugins that inject global JavaScript, conflict with caching layers, and couple the application to a specific vendor.
+
+A framework-level solution should be lightweight, follow the same architectural patterns as the rest of the framework, and give developers full control over which scripts load under which conditions.
+
+## Cookie-based consent storage
+
+Consent state is stored in a single JSON cookie (`gdpr_consent`):
+
+```json
+{"analytics": true, "marketing": false, "functional": true}
+```
+
+This design has three advantages:
+
+1. **No database dependency.** Consent state is read from `$_COOKIE` on every request. No `wp_options` query, no user meta lookup.
+2. **Immediate availability.** PHP reads the cookie at request start. Server-side code can gate script output before any HTML is sent.
+3. **No user account required.** Anonymous visitors get the same consent mechanism as logged-in users.
+
+The tradeoff is that consent does not survive cookie deletion and cannot be audited server-side. For sites requiring an audit trail, a custom `ConsentStorageInterface` adapter can persist consent to a database while still reading from the cookie for performance.
+
+## Consent categories vs. individual scripts
+
+The module separates **categories** (analytics, marketing, functional) from **scripts** (Google Analytics, HubSpot, Hotjar). Each script declares which category it belongs to via `getCategoryKey()`.
+
+This separation means:
+
+- Users consent to categories, not to individual scripts. The banner stays simple.
+- Developers can add or remove scripts without changing consent logic.
+- Required categories (e.g., functional cookies) are always loaded regardless of user choice.
+
+## Script loading flow
+
+```
+Request arrives
+    │
+    ├── CookieConsentStorage reads $_COOKIE['gdpr_consent']
+    │
+    ├── wp_head fires
+    │   └── RegisterGdpr::renderHeadScripts()
+    │       ├── For each script with location='head', sorted by priority:
+    │       │   ├── Is category required? → output script
+    │       │   └── Has user consented? → output script
+    │       └── Skip otherwise
+    │
+    ├── wp_footer fires
+    │   ├── RegisterGdpr::renderFooterScripts() (same logic, location='footer')
+    │   └── RegisterGdpr::renderConsentBanner()
+    │       └── Renders banner HTML/CSS/JS inline
+    │
+    └── User interacts with banner
+        └── JavaScript sets cookie, page reloads
+            └── Next request picks up new consent state
+```
+
+The page reload after consent is intentional. It ensures PHP sees the updated cookie values and can gate scripts server-side. This prevents the flash of tracking scripts that client-only solutions suffer from.
+
+## Presets: reducing boilerplate
+
+Common tracking services (Google Analytics, GTM, Hotjar, HubSpot, Google Ads) follow well-known patterns. The `Preset/` namespace provides ready-to-use `TrackingScriptInterface` implementations that only require a tracking ID:
+
+```php
+new GoogleAnalyticsScript('G-XXXXXXX')
+```
+
+Each preset encodes the correct snippet, location, priority, and consent category. Developers register them in their DI configuration with a single `->tag('wordpress.tracking_script')` call.
+
+Presets are not special — they are regular `TrackingScriptInterface` implementations. Developers can create their own presets for any tracking service by following the same pattern.
+
+## Why not `wp_enqueue_script`?
+
+WordPress's asset pipeline (`wp_enqueue_script` / `wp_register_script`) is designed for theme and plugin JavaScript files. Tracking scripts have different requirements:
+
+- They must render **inline snippets**, not just external files.
+- They must execute **before** any other script (GTM wants priority 1 in `<head>`).
+- They must be **conditionally gated** by consent state, not by page context.
+- They often combine an external loader (`gtag.js`) with an inline configuration block.
+
+Direct `<script>` output via `wp_head` / `wp_footer` hooks gives full control over ordering and format without fighting the enqueue system.
+
+## Extending the module
+
+The module follows the same extension patterns as the rest of the framework:
+
+- **New consent categories**: Implement `ConsentCategoryInterface` and tag with `wordpress.consent_category`.
+- **New tracking scripts**: Implement `TrackingScriptInterface` and tag with `wordpress.tracking_script`.
+- **Custom storage**: Implement `ConsentStorageInterface` and override the port binding in `WordPressExtension`.
+- **Custom banner**: Replace or extend `ConsentBanner` via DI service decoration.

--- a/docs/how-to/manage-gdpr-consent.md
+++ b/docs/how-to/manage-gdpr-consent.md
@@ -1,0 +1,195 @@
+# How to Manage GDPR Consent and Tracking Scripts
+
+The GDPR module provides a consent banner, cookie-based consent storage, and conditional script loading. Scripts only execute when the user has granted consent for their category.
+
+## Define consent categories
+
+Create a class implementing `ConsentCategoryInterface` for each category you need:
+
+```php
+<?php
+
+namespace MyTheme\Gdpr;
+
+use BackTo\Framework\Gdpr\Contracts\ConsentCategoryInterface;
+
+class AnalyticsCategory implements ConsentCategoryInterface
+{
+    public function getKey(): string { return 'analytics'; }
+    public function getLabel(): string { return 'Analytics'; }
+    public function getDescription(): string { return 'Cookies used for traffic analysis and statistics.'; }
+    public function isRequired(): bool { return false; }
+}
+```
+
+Or use the `ConsentCategory` entity directly in your service configuration:
+
+```php
+use BackTo\Framework\Gdpr\Entity\ConsentCategory;
+
+$services->set('app.category.analytics', ConsentCategory::class)
+    ->args(['analytics', 'Analytics', 'Cookies used for traffic analysis.', false])
+    ->tag('wordpress.consent_category');
+```
+
+Categories tagged with `wordpress.consent_category` are automatically collected into the `ConsentCategoryRegistry`.
+
+## Add a tracking script
+
+Implement `TrackingScriptInterface` or use the `TrackingScript` entity:
+
+```php
+use BackTo\Framework\Gdpr\Entity\TrackingScript;
+
+$services->set('app.script.ga', TrackingScript::class)
+    ->args([
+        'google-analytics',  // handle
+        'analytics',         // categoryKey (must match a consent category)
+        "gtag('config', 'G-XXXXXXX');", // source (inline JS or URL)
+        true,                // inline (true = inline code, false = external URL)
+        'head',              // location ('head' or 'footer')
+        5,                   // priority (lower = earlier execution)
+    ])
+    ->tag('wordpress.tracking_script');
+```
+
+## Use built-in presets
+
+The framework ships with preconfigured scripts for popular services. Each preset only requires the service's tracking ID.
+
+### Google Tag Manager
+
+```php
+use BackTo\Framework\Gdpr\Preset\GoogleTagManagerScript;
+
+$services->set(GoogleTagManagerScript::class)
+    ->args(['GTM-XXXXXXX'])
+    ->tag('wordpress.tracking_script');
+```
+
+### Google Analytics (GA4)
+
+GA4 requires the `gtag.js` loader and the configuration script. Register both:
+
+```php
+use BackTo\Framework\Gdpr\Preset\GtagLoaderScript;
+use BackTo\Framework\Gdpr\Preset\GoogleAnalyticsScript;
+
+$services->set(GtagLoaderScript::class)
+    ->args(['G-XXXXXXX'])
+    ->tag('wordpress.tracking_script');
+
+$services->set(GoogleAnalyticsScript::class)
+    ->args(['G-XXXXXXX'])
+    ->tag('wordpress.tracking_script');
+```
+
+### Google Ads
+
+```php
+use BackTo\Framework\Gdpr\Preset\GtagLoaderScript;
+use BackTo\Framework\Gdpr\Preset\GoogleAdsScript;
+
+$services->set('app.gtag_loader_ads', GtagLoaderScript::class)
+    ->args(['AW-XXXXXXX', 'marketing'])
+    ->tag('wordpress.tracking_script');
+
+$services->set(GoogleAdsScript::class)
+    ->args(['AW-XXXXXXX'])
+    ->tag('wordpress.tracking_script');
+```
+
+### Hotjar
+
+```php
+use BackTo\Framework\Gdpr\Preset\HotjarScript;
+
+$services->set(HotjarScript::class)
+    ->args(['1234567'])
+    ->tag('wordpress.tracking_script');
+```
+
+### HubSpot
+
+```php
+use BackTo\Framework\Gdpr\Preset\HubSpotScript;
+
+$services->set(HubSpotScript::class)
+    ->args(['12345678'])
+    ->tag('wordpress.tracking_script');
+```
+
+## Preset summary
+
+| Preset | Category | Location | Param |
+|--------|----------|----------|-------|
+| `GoogleTagManagerScript` | analytics | head | Container ID (`GTM-XXX`) |
+| `GtagLoaderScript` | analytics* | head | Tracking ID (loads `gtag.js`) |
+| `GoogleAnalyticsScript` | analytics | head | Measurement ID (`G-XXX`) |
+| `GoogleAdsScript` | marketing | head | Conversion ID (`AW-XXX`) |
+| `HotjarScript` | analytics | head | Site ID |
+| `HubSpotScript` | marketing | footer | Portal ID |
+
+*`GtagLoaderScript` accepts an optional second argument to override the category (e.g., `'marketing'` for Google Ads).*
+
+## Check consent in your own code
+
+Inject `ConsentStorageInterface` to read consent state server-side:
+
+```php
+use BackTo\Framework\Gdpr\Contracts\ConsentStorageInterface;
+
+class MyService
+{
+    public function __construct(private ConsentStorageInterface $consentStorage)
+    {
+    }
+
+    public function shouldTrack(): bool
+    {
+        return $this->consentStorage->hasConsent('analytics');
+    }
+}
+```
+
+## Create a custom tracking script preset
+
+Implement `TrackingScriptInterface` with hardcoded defaults:
+
+```php
+<?php
+
+namespace MyTheme\Gdpr;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+
+class FacebookPixelScript implements TrackingScriptInterface
+{
+    public function __construct(private readonly string $pixelId)
+    {
+    }
+
+    public function getHandle(): string { return 'facebook-pixel'; }
+    public function getCategoryKey(): string { return 'marketing'; }
+    public function getSource(): string
+    {
+        return "!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?"
+            . "n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;"
+            . "n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;"
+            . "t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,"
+            . "document,'script','https://connect.facebook.net/en_US/fbevents.js');"
+            . "fbq('init','" . $this->pixelId . "');fbq('track','PageView');";
+    }
+    public function isInline(): bool { return true; }
+    public function getLocation(): string { return 'head'; }
+    public function getPriority(): int { return 10; }
+}
+```
+
+Register it in your DI config:
+
+```php
+$services->set(FacebookPixelScript::class)
+    ->args(['1234567890'])
+    ->tag('wordpress.tracking_script');
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ Practical guides for accomplishing specific tasks.
 - [How to use WP-CLI scaffolding](how-to/use-cli-scaffolding.md)
 - [How to use the observability module](how-to/use-observability.md)
 - [How to debug with Query Monitor](how-to/debug-with-query-monitor.md)
+- [How to manage GDPR consent and tracking scripts](how-to/manage-gdpr-consent.md)
 
 ## Reference
 
@@ -44,3 +45,4 @@ Background, design decisions, and conceptual understanding.
 - [Why a WordPress framework?](explanation/why-a-framework.md)
 - [Clean Architecture and DDD in WordPress](explanation/clean-architecture.md)
 - [Vendor scoping with php-scoper](explanation/vendor-scoping.md)
+- [GDPR consent management design](explanation/gdpr-consent-design.md)

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -316,6 +316,73 @@ interface PerformanceCollectorInterface
 }
 ```
 
+## GDPR contracts
+
+### `ConsentCategoryInterface`
+
+```php
+interface ConsentCategoryInterface
+{
+    public function getKey(): string;
+    public function getLabel(): string;
+    public function getDescription(): string;
+    public function isRequired(): bool;
+}
+```
+
+### `TrackingScriptInterface`
+
+```php
+interface TrackingScriptInterface
+{
+    public function getHandle(): string;
+    public function getCategoryKey(): string;
+    public function getSource(): string;
+    public function isInline(): bool;
+    public function getLocation(): string;
+    public function getPriority(): int;
+}
+```
+
+### `ConsentStorageInterface`
+
+Port interface for reading user consent state.
+
+```php
+interface ConsentStorageInterface
+{
+    /** @return array<string, bool> */
+    public function getConsent(): array;
+    public function hasConsent(string $categoryKey): bool;
+    public function isConsentGiven(): bool;
+}
+```
+
+### `ConsentCategoryRegistryInterface`
+
+```php
+interface ConsentCategoryRegistryInterface
+{
+    public function add(ConsentCategoryInterface $category): self;
+    /** @return ConsentCategoryInterface[] */
+    public function getCategories(): array;
+    public function get(string $key): ?ConsentCategoryInterface;
+}
+```
+
+### `TrackingScriptRegistryInterface`
+
+```php
+interface TrackingScriptRegistryInterface
+{
+    public function add(TrackingScriptInterface $script): self;
+    /** @return TrackingScriptInterface[] */
+    public function getScripts(): array;
+    /** @return TrackingScriptInterface[] */
+    public function getScriptsByCategory(string $categoryKey): array;
+}
+```
+
 ## Cache contracts
 
 ### `CacheInterface`

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -236,6 +236,29 @@ Comprehensive WordPress security hardening with autoconfigured rules.
 | `HealthCheck\SecurityHealthCheck` | Health check: critical rules active, PHP version, file editor |
 | `AuditLogAdminPage` | Admin page for viewing audit logs |
 
+## Gdpr
+
+GDPR consent management with cookie-based storage, consent banner, and conditional script loading.
+
+| Class | Role |
+|-------|------|
+| `Entity\ConsentCategory` | Immutable value object for a consent category |
+| `Entity\TrackingScript` | Immutable value object for a tracking script |
+| `ConsentCategoryRegistry` | Collects registered consent categories |
+| `TrackingScriptRegistry` | Collects registered tracking scripts |
+| `RegisterGdpr` | Application orchestrator (hooks into `wp_head` / `wp_footer`) |
+| `ConsentBanner` | Renders the consent banner HTML/CSS/JS |
+| `Contracts\ConsentCategoryInterface` | Interface for consent categories |
+| `Contracts\TrackingScriptInterface` | Interface for tracking scripts |
+| `Contracts\ConsentStorageInterface` | Port for reading user consent |
+| `Infrastructure\CookieConsentStorage` | Cookie-based adapter |
+| `Preset\GoogleTagManagerScript` | GTM preset (container ID) |
+| `Preset\GtagLoaderScript` | gtag.js loader preset (tracking ID) |
+| `Preset\GoogleAnalyticsScript` | GA4 preset (measurement ID) |
+| `Preset\GoogleAdsScript` | Google Ads preset (conversion ID) |
+| `Preset\HotjarScript` | Hotjar preset (site ID) |
+| `Preset\HubSpotScript` | HubSpot preset (portal ID) |
+
 ## Compose
 
 Framework kernel and container management.

--- a/src/Compose/Resources/config/services.php
+++ b/src/Compose/Resources/config/services.php
@@ -18,4 +18,6 @@ return function (ContainerConfigurator $configurator) {
              ->exclude('../../../PostType/{DependencyInjection,Entity,Tests,Contracts}');
     $services->load('BackTo\\Framework\\Taxonomy\\', '../../../Taxonomy/*')
              ->exclude('../../../Taxonomy/{DependencyInjection,Entity,Tests,Contracts}');
+    $services->load('BackTo\\Framework\\Gdpr\\', '../../../Gdpr/*')
+             ->exclude('../../../Gdpr/{DependencyInjection,Entity,Tests,Contracts}');
 };

--- a/src/Compose/Tests/WordPressExtensionTest.php
+++ b/src/Compose/Tests/WordPressExtensionTest.php
@@ -34,6 +34,11 @@ use BackTo\Framework\RestApi\DependencyInjection\Compiler\RegisterRestRoutePass;
 use BackTo\Framework\RestApi\RestApiExtension;
 use BackTo\Framework\Security\Contracts\SecurityRuleInterface;
 use BackTo\Framework\Security\DependencyInjection\Compiler\RegisterSecurityRulePass;
+use BackTo\Framework\Gdpr\Contracts\ConsentCategoryInterface;
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+use BackTo\Framework\Gdpr\DependencyInjection\Compiler\RegisterConsentCategoryPass;
+use BackTo\Framework\Gdpr\DependencyInjection\Compiler\RegisterTrackingScriptPass;
+use BackTo\Framework\Gdpr\GdprExtension;
 use BackTo\Framework\Security\SecurityExtension;
 use BackTo\Framework\Seo\SeoExtension;
 use BackTo\Framework\Taxonomy\Contracts\TaxonomyInterface;
@@ -75,6 +80,7 @@ class WordPressExtensionTest extends TestCase
             'Options' => [new OptionsExtension()],
             'Cache' => [new CacheExtension()],
             'Seo' => [new SeoExtension()],
+            'Gdpr' => [new GdprExtension()],
         ];
     }
 
@@ -108,6 +114,8 @@ class WordPressExtensionTest extends TestCase
             'RestRoute' => [new RestApiExtension(), RestRouteInterface::class, 'wordpress.rest_route'],
             'HealthCheck' => [new ObservabilityExtension(), HealthCheckInterface::class, 'wordpress.health_check'],
             'SecurityRule' => [new SecurityExtension(), SecurityRuleInterface::class, 'wordpress.security_rule'],
+            'ConsentCategory' => [new GdprExtension(), ConsentCategoryInterface::class, 'wordpress.consent_category'],
+            'TrackingScript' => [new GdprExtension(), TrackingScriptInterface::class, 'wordpress.tracking_script'],
         ];
     }
 
@@ -137,6 +145,8 @@ class WordPressExtensionTest extends TestCase
             'RestRoute' => [new RestApiExtension(), RegisterRestRoutePass::class],
             'HealthCheck' => [new ObservabilityExtension(), RegisterHealthCheckPass::class],
             'SecurityRule' => [new SecurityExtension(), RegisterSecurityRulePass::class],
+            'ConsentCategory' => [new GdprExtension(), RegisterConsentCategoryPass::class],
+            'TrackingScript' => [new GdprExtension(), RegisterTrackingScriptPass::class],
         ];
     }
 
@@ -184,6 +194,7 @@ class WordPressExtensionTest extends TestCase
             new OptionsExtension(),
             new CacheExtension(),
             new SeoExtension(),
+            new GdprExtension(),
         ];
 
         foreach ($extensions as $extension) {

--- a/src/Compose/WordPressContainer.php
+++ b/src/Compose/WordPressContainer.php
@@ -18,6 +18,7 @@ use BackTo\Framework\Options\OptionsExtension;
 use BackTo\Framework\PostMeta\PostMetaExtension;
 use BackTo\Framework\PostType\PostTypeExtension;
 use BackTo\Framework\RestApi\RestApiExtension;
+use BackTo\Framework\Gdpr\GdprExtension;
 use BackTo\Framework\Security\SecurityExtension;
 use BackTo\Framework\Seo\SeoExtension;
 use BackTo\Framework\Taxonomy\TaxonomyExtension;
@@ -230,6 +231,7 @@ trait WordPressContainer
             new RestApiExtension(),
             new ObservabilityExtension(),
             new SecurityExtension(),
+            new GdprExtension(),
         ];
     }
 

--- a/src/Gdpr/ConsentBanner.php
+++ b/src/Gdpr/ConsentBanner.php
@@ -1,0 +1,325 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr;
+
+use BackTo\Framework\Gdpr\Contracts\ConsentCategoryInterface;
+use BackTo\Framework\Gdpr\Contracts\ConsentStorageInterface;
+
+class ConsentBanner
+{
+    public function __construct(
+        private readonly ConsentCategoryRegistry $categoryRegistry,
+        private readonly ConsentStorageInterface $consentStorage,
+    ) {
+    }
+
+    public function render(): string
+    {
+        $categories = $this->categoryRegistry->getCategories();
+
+        if ($categories === []) {
+            return '';
+        }
+
+        $categoriesJson = json_encode(
+            $this->buildCategoriesData($categories),
+            JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP
+        );
+
+        $consentGiven = $this->consentStorage->isConsentGiven();
+        $currentConsent = json_encode($this->consentStorage->getConsent(), JSON_THROW_ON_ERROR | JSON_HEX_TAG);
+
+        $checkboxesHtml = $this->renderCheckboxes($categories);
+
+        return <<<HTML
+        <div id="gdpr-consent-banner" style="display:none;">
+            <style>{$this->getCss()}</style>
+            <div class="gdpr-banner__overlay"></div>
+            <div class="gdpr-banner__dialog" role="dialog" aria-label="Gestion des cookies" aria-modal="true">
+                <div class="gdpr-banner__content">
+                    <h2 class="gdpr-banner__title">Gestion des cookies</h2>
+                    <p class="gdpr-banner__text">
+                        Nous utilisons des cookies pour personnaliser votre experience et analyser notre trafic.
+                        Vous pouvez choisir les categories de cookies que vous acceptez.
+                    </p>
+                    <div class="gdpr-banner__categories">
+                        {$checkboxesHtml}
+                    </div>
+                    <div class="gdpr-banner__actions">
+                        <button type="button" class="gdpr-banner__btn gdpr-banner__btn--reject" data-gdpr-action="reject">
+                            Tout refuser
+                        </button>
+                        <button type="button" class="gdpr-banner__btn gdpr-banner__btn--save" data-gdpr-action="save">
+                            Enregistrer mes choix
+                        </button>
+                        <button type="button" class="gdpr-banner__btn gdpr-banner__btn--accept" data-gdpr-action="accept">
+                            Tout accepter
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <button type="button" id="gdpr-consent-toggle" class="gdpr-toggle" style="display:none;" aria-label="Gerer les cookies">
+            Gerer les cookies
+        </button>
+        <script>
+        (function() {
+            var COOKIE_NAME = 'gdpr_consent';
+            var COOKIE_DAYS = 365;
+            var categories = {$categoriesJson};
+            var consentGiven = {$this->boolToJs($consentGiven)};
+            var currentConsent = {$currentConsent};
+
+            var banner = document.getElementById('gdpr-consent-banner');
+            var toggle = document.getElementById('gdpr-consent-toggle');
+
+            function setCookie(name, value, days) {
+                var expires = new Date(Date.now() + days * 864e5).toUTCString();
+                document.cookie = name + '=' + encodeURIComponent(value) + ';expires=' + expires + ';path=/;SameSite=Lax';
+            }
+
+            function saveConsent(consent) {
+                setCookie(COOKIE_NAME, JSON.stringify(consent), COOKIE_DAYS);
+                window.location.reload();
+            }
+
+            function showBanner() {
+                banner.style.display = 'block';
+                toggle.style.display = 'none';
+            }
+
+            function hideBanner() {
+                banner.style.display = 'none';
+                toggle.style.display = 'block';
+            }
+
+            function getCheckboxConsent() {
+                var consent = {};
+                for (var i = 0; i < categories.length; i++) {
+                    var key = categories[i].key;
+                    var checkbox = document.getElementById('gdpr-cat-' + key);
+                    consent[key] = checkbox ? checkbox.checked : categories[i].required;
+                }
+                return consent;
+            }
+
+            function initCheckboxes() {
+                for (var i = 0; i < categories.length; i++) {
+                    var key = categories[i].key;
+                    var checkbox = document.getElementById('gdpr-cat-' + key);
+                    if (checkbox && consentGiven && currentConsent[key] !== undefined) {
+                        checkbox.checked = !!currentConsent[key];
+                    }
+                }
+            }
+
+            banner.addEventListener('click', function(e) {
+                var action = e.target.getAttribute('data-gdpr-action');
+                if (!action) return;
+
+                if (action === 'accept') {
+                    var consent = {};
+                    for (var i = 0; i < categories.length; i++) {
+                        consent[categories[i].key] = true;
+                    }
+                    saveConsent(consent);
+                } else if (action === 'reject') {
+                    var consent = {};
+                    for (var i = 0; i < categories.length; i++) {
+                        consent[categories[i].key] = !!categories[i].required;
+                    }
+                    saveConsent(consent);
+                } else if (action === 'save') {
+                    saveConsent(getCheckboxConsent());
+                }
+            });
+
+            toggle.addEventListener('click', function() {
+                showBanner();
+            });
+
+            initCheckboxes();
+
+            if (!consentGiven) {
+                showBanner();
+            } else {
+                hideBanner();
+            }
+        })();
+        </script>
+        HTML;
+    }
+
+    /**
+     * @param ConsentCategoryInterface[] $categories
+     */
+    private function renderCheckboxes(array $categories): string
+    {
+        $html = '';
+
+        foreach ($categories as $category) {
+            $key = htmlspecialchars($category->getKey(), ENT_QUOTES, 'UTF-8');
+            $label = htmlspecialchars($category->getLabel(), ENT_QUOTES, 'UTF-8');
+            $description = htmlspecialchars($category->getDescription(), ENT_QUOTES, 'UTF-8');
+            $checked = $category->isRequired() ? ' checked' : '';
+            $disabled = $category->isRequired() ? ' disabled' : '';
+
+            $html .= <<<CHECKBOX
+            <label class="gdpr-banner__category" for="gdpr-cat-{$key}">
+                <input type="checkbox" id="gdpr-cat-{$key}" data-gdpr-category="{$key}"{$checked}{$disabled}>
+                <span class="gdpr-banner__category-label">{$label}</span>
+                <span class="gdpr-banner__category-desc">{$description}</span>
+            </label>
+            CHECKBOX;
+        }
+
+        return $html;
+    }
+
+    /**
+     * @param ConsentCategoryInterface[] $categories
+     * @return array<int, array{key: string, label: string, required: bool}>
+     */
+    private function buildCategoriesData(array $categories): array
+    {
+        $data = [];
+
+        foreach ($categories as $category) {
+            $data[] = [
+                'key' => $category->getKey(),
+                'label' => $category->getLabel(),
+                'required' => $category->isRequired(),
+            ];
+        }
+
+        return $data;
+    }
+
+    private function boolToJs(bool $value): string
+    {
+        return $value ? 'true' : 'false';
+    }
+
+    private function getCss(): string
+    {
+        return <<<'CSS'
+        #gdpr-consent-banner {
+            position: fixed;
+            inset: 0;
+            z-index: 999999;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            font-size: 14px;
+            line-height: 1.5;
+        }
+        .gdpr-banner__overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.5);
+        }
+        .gdpr-banner__dialog {
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            background: #fff;
+            box-shadow: 0 -2px 16px rgba(0, 0, 0, 0.15);
+            z-index: 1;
+            max-height: 90vh;
+            overflow-y: auto;
+        }
+        .gdpr-banner__content {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 24px;
+        }
+        .gdpr-banner__title {
+            margin: 0 0 8px;
+            font-size: 18px;
+            font-weight: 600;
+            color: #1a1a1a;
+        }
+        .gdpr-banner__text {
+            margin: 0 0 16px;
+            color: #555;
+        }
+        .gdpr-banner__categories {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            margin-bottom: 16px;
+        }
+        .gdpr-banner__category {
+            display: flex;
+            align-items: flex-start;
+            gap: 8px;
+            padding: 8px 12px;
+            background: #f7f7f7;
+            border-radius: 6px;
+            cursor: pointer;
+        }
+        .gdpr-banner__category input {
+            margin-top: 3px;
+            flex-shrink: 0;
+        }
+        .gdpr-banner__category-label {
+            font-weight: 500;
+            color: #1a1a1a;
+        }
+        .gdpr-banner__category-desc {
+            color: #777;
+            font-size: 13px;
+        }
+        .gdpr-banner__actions {
+            display: flex;
+            gap: 8px;
+            justify-content: flex-end;
+            flex-wrap: wrap;
+        }
+        .gdpr-banner__btn {
+            padding: 10px 20px;
+            border: none;
+            border-radius: 6px;
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: opacity 0.2s;
+        }
+        .gdpr-banner__btn:hover {
+            opacity: 0.85;
+        }
+        .gdpr-banner__btn--accept {
+            background: #2563eb;
+            color: #fff;
+        }
+        .gdpr-banner__btn--reject {
+            background: #e5e7eb;
+            color: #374151;
+        }
+        .gdpr-banner__btn--save {
+            background: #f3f4f6;
+            color: #374151;
+            border: 1px solid #d1d5db;
+        }
+        .gdpr-toggle {
+            position: fixed;
+            bottom: 16px;
+            left: 16px;
+            z-index: 999998;
+            padding: 8px 16px;
+            background: #2563eb;
+            color: #fff;
+            border: none;
+            border-radius: 20px;
+            font-size: 13px;
+            cursor: pointer;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }
+        .gdpr-toggle:hover {
+            opacity: 0.85;
+        }
+        CSS;
+    }
+}

--- a/src/Gdpr/ConsentCategoryRegistry.php
+++ b/src/Gdpr/ConsentCategoryRegistry.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr;
+
+use BackTo\Framework\Contracts\RegistryInterface;
+use BackTo\Framework\Gdpr\Contracts\ConsentCategoryInterface;
+use BackTo\Framework\Gdpr\Contracts\ConsentCategoryRegistryInterface;
+
+class ConsentCategoryRegistry implements RegistryInterface, ConsentCategoryRegistryInterface
+{
+    /** @var array<string, ConsentCategoryInterface> */
+    private array $categories = [];
+
+    public function add(ConsentCategoryInterface $category): ConsentCategoryRegistryInterface
+    {
+        $this->categories[$category->getKey()] = $category;
+
+        return $this;
+    }
+
+    /**
+     * @return ConsentCategoryInterface[]
+     */
+    public function getCategories(): array
+    {
+        return $this->categories;
+    }
+
+    public function get(string $key): ?ConsentCategoryInterface
+    {
+        return $this->categories[$key] ?? null;
+    }
+}

--- a/src/Gdpr/Contracts/ConsentCategoryInterface.php
+++ b/src/Gdpr/Contracts/ConsentCategoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Contracts;
+
+interface ConsentCategoryInterface
+{
+    public function getKey(): string;
+
+    public function getLabel(): string;
+
+    public function getDescription(): string;
+
+    public function isRequired(): bool;
+}

--- a/src/Gdpr/Contracts/ConsentCategoryRegistryInterface.php
+++ b/src/Gdpr/Contracts/ConsentCategoryRegistryInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Contracts;
+
+interface ConsentCategoryRegistryInterface
+{
+    public function add(ConsentCategoryInterface $category): self;
+
+    /**
+     * @return ConsentCategoryInterface[]
+     */
+    public function getCategories(): array;
+
+    public function get(string $key): ?ConsentCategoryInterface;
+}

--- a/src/Gdpr/Contracts/ConsentStorageInterface.php
+++ b/src/Gdpr/Contracts/ConsentStorageInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Contracts;
+
+interface ConsentStorageInterface
+{
+    /**
+     * @return array<string, bool>
+     */
+    public function getConsent(): array;
+
+    public function hasConsent(string $categoryKey): bool;
+
+    public function isConsentGiven(): bool;
+}

--- a/src/Gdpr/Contracts/TrackingScriptInterface.php
+++ b/src/Gdpr/Contracts/TrackingScriptInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Contracts;
+
+interface TrackingScriptInterface
+{
+    public function getHandle(): string;
+
+    public function getCategoryKey(): string;
+
+    public function getSource(): string;
+
+    public function isInline(): bool;
+
+    public function getLocation(): string;
+
+    public function getPriority(): int;
+}

--- a/src/Gdpr/Contracts/TrackingScriptRegistryInterface.php
+++ b/src/Gdpr/Contracts/TrackingScriptRegistryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Contracts;
+
+interface TrackingScriptRegistryInterface
+{
+    public function add(TrackingScriptInterface $script): self;
+
+    /**
+     * @return TrackingScriptInterface[]
+     */
+    public function getScripts(): array;
+
+    /**
+     * @return TrackingScriptInterface[]
+     */
+    public function getScriptsByCategory(string $categoryKey): array;
+}

--- a/src/Gdpr/DependencyInjection/Compiler/RegisterConsentCategoryPass.php
+++ b/src/Gdpr/DependencyInjection/Compiler/RegisterConsentCategoryPass.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\DependencyInjection\Compiler;
+
+use BackTo\Framework\Compose\DependencyInjection\Compiler\AbstractTaggedServiceCompilerPass;
+use BackTo\Framework\Gdpr\ConsentCategoryRegistry;
+
+class RegisterConsentCategoryPass extends AbstractTaggedServiceCompilerPass
+{
+    protected function getRegistryClass(): string
+    {
+        return ConsentCategoryRegistry::class;
+    }
+
+    protected function getTag(): string
+    {
+        return 'wordpress.consent_category';
+    }
+}

--- a/src/Gdpr/DependencyInjection/Compiler/RegisterTrackingScriptPass.php
+++ b/src/Gdpr/DependencyInjection/Compiler/RegisterTrackingScriptPass.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\DependencyInjection\Compiler;
+
+use BackTo\Framework\Compose\DependencyInjection\Compiler\AbstractTaggedServiceCompilerPass;
+use BackTo\Framework\Gdpr\TrackingScriptRegistry;
+
+class RegisterTrackingScriptPass extends AbstractTaggedServiceCompilerPass
+{
+    protected function getRegistryClass(): string
+    {
+        return TrackingScriptRegistry::class;
+    }
+
+    protected function getTag(): string
+    {
+        return 'wordpress.tracking_script';
+    }
+}

--- a/src/Gdpr/Entity/ConsentCategory.php
+++ b/src/Gdpr/Entity/ConsentCategory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Entity;
+
+use BackTo\Framework\Gdpr\Contracts\ConsentCategoryInterface;
+
+final class ConsentCategory implements ConsentCategoryInterface
+{
+    public function __construct(
+        private readonly string $key,
+        private readonly string $label,
+        private readonly string $description = '',
+        private readonly bool $required = false,
+    ) {
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function isRequired(): bool
+    {
+        return $this->required;
+    }
+}

--- a/src/Gdpr/Entity/TrackingScript.php
+++ b/src/Gdpr/Entity/TrackingScript.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Entity;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+
+final class TrackingScript implements TrackingScriptInterface
+{
+    public function __construct(
+        private readonly string $handle,
+        private readonly string $categoryKey,
+        private readonly string $source,
+        private readonly bool $inline = false,
+        private readonly string $location = 'head',
+        private readonly int $priority = 10,
+    ) {
+    }
+
+    public function getHandle(): string
+    {
+        return $this->handle;
+    }
+
+    public function getCategoryKey(): string
+    {
+        return $this->categoryKey;
+    }
+
+    public function getSource(): string
+    {
+        return $this->source;
+    }
+
+    public function isInline(): bool
+    {
+        return $this->inline;
+    }
+
+    public function getLocation(): string
+    {
+        return $this->location;
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+}

--- a/src/Gdpr/GdprExtension.php
+++ b/src/Gdpr/GdprExtension.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr;
+
+use BackTo\Framework\Contracts\ExtensionInterface;
+use BackTo\Framework\Gdpr\Contracts\ConsentCategoryInterface;
+use BackTo\Framework\Gdpr\Contracts\ConsentStorageInterface;
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+use BackTo\Framework\Gdpr\DependencyInjection\Compiler\RegisterConsentCategoryPass;
+use BackTo\Framework\Gdpr\DependencyInjection\Compiler\RegisterTrackingScriptPass;
+use BackTo\Framework\Gdpr\Infrastructure\CookieConsentStorage;
+use BackToVendor\Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class GdprExtension implements ExtensionInterface
+{
+    public function getBundle(): ?array
+    {
+        return [
+            'dir' => __DIR__,
+            'namespace' => 'BackTo\\Framework\\Gdpr\\',
+            'exclude' => '{DependencyInjection,Entity,Tests,Contracts,Infrastructure,Preset}',
+        ];
+    }
+
+    public function register(ContainerBuilder $containerBuilder): void
+    {
+        $containerBuilder->registerForAutoconfiguration(ConsentCategoryInterface::class)
+            ->addTag('wordpress.consent_category');
+
+        $containerBuilder->registerForAutoconfiguration(TrackingScriptInterface::class)
+            ->addTag('wordpress.tracking_script');
+
+        $containerBuilder->addCompilerPass(new RegisterConsentCategoryPass());
+        $containerBuilder->addCompilerPass(new RegisterTrackingScriptPass());
+
+        $containerBuilder->register(ConsentStorageInterface::class, CookieConsentStorage::class);
+        $containerBuilder->setAlias(CookieConsentStorage::class, ConsentStorageInterface::class);
+    }
+
+    public function getDefaultConfiguration(): array
+    {
+        return [];
+    }
+}

--- a/src/Gdpr/Infrastructure/CookieConsentStorage.php
+++ b/src/Gdpr/Infrastructure/CookieConsentStorage.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Infrastructure;
+
+use BackTo\Framework\Gdpr\Contracts\ConsentStorageInterface;
+
+class CookieConsentStorage implements ConsentStorageInterface
+{
+    private const COOKIE_NAME = 'gdpr_consent';
+
+    /**
+     * @return array<string, bool>
+     */
+    public function getConsent(): array
+    {
+        if (!isset($_COOKIE[self::COOKIE_NAME])) {
+            return [];
+        }
+
+        $decoded = json_decode($_COOKIE[self::COOKIE_NAME], true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    public function hasConsent(string $categoryKey): bool
+    {
+        return ($this->getConsent()[$categoryKey] ?? false) === true;
+    }
+
+    public function isConsentGiven(): bool
+    {
+        return isset($_COOKIE[self::COOKIE_NAME]);
+    }
+}

--- a/src/Gdpr/Preset/GoogleAdsScript.php
+++ b/src/Gdpr/Preset/GoogleAdsScript.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Preset;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+
+final class GoogleAdsScript implements TrackingScriptInterface
+{
+    public function __construct(
+        private readonly string $conversionId,
+    ) {
+    }
+
+    public function getHandle(): string
+    {
+        return 'google-ads';
+    }
+
+    public function getCategoryKey(): string
+    {
+        return 'marketing';
+    }
+
+    public function getSource(): string
+    {
+        return "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}"
+            . "gtag('js',new Date());gtag('config','" . $this->conversionId . "');";
+    }
+
+    public function isInline(): bool
+    {
+        return true;
+    }
+
+    public function getLocation(): string
+    {
+        return 'head';
+    }
+
+    public function getPriority(): int
+    {
+        return 5;
+    }
+}

--- a/src/Gdpr/Preset/GoogleAnalyticsScript.php
+++ b/src/Gdpr/Preset/GoogleAnalyticsScript.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Preset;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+
+final class GoogleAnalyticsScript implements TrackingScriptInterface
+{
+    public function __construct(
+        private readonly string $measurementId,
+    ) {
+    }
+
+    public function getHandle(): string
+    {
+        return 'google-analytics';
+    }
+
+    public function getCategoryKey(): string
+    {
+        return 'analytics';
+    }
+
+    public function getSource(): string
+    {
+        return "window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}"
+            . "gtag('js',new Date());gtag('config','" . $this->measurementId . "');";
+    }
+
+    public function isInline(): bool
+    {
+        return true;
+    }
+
+    public function getLocation(): string
+    {
+        return 'head';
+    }
+
+    public function getPriority(): int
+    {
+        return 5;
+    }
+}

--- a/src/Gdpr/Preset/GoogleTagManagerScript.php
+++ b/src/Gdpr/Preset/GoogleTagManagerScript.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Preset;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+
+final class GoogleTagManagerScript implements TrackingScriptInterface
+{
+    public function __construct(
+        private readonly string $containerId,
+    ) {
+    }
+
+    public function getHandle(): string
+    {
+        return 'google-tag-manager';
+    }
+
+    public function getCategoryKey(): string
+    {
+        return 'analytics';
+    }
+
+    public function getSource(): string
+    {
+        return "(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':"
+            . "new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],"
+            . "j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src="
+            . "'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);"
+            . "})(window,document,'script','dataLayer','" . $this->containerId . "');";
+    }
+
+    public function isInline(): bool
+    {
+        return true;
+    }
+
+    public function getLocation(): string
+    {
+        return 'head';
+    }
+
+    public function getPriority(): int
+    {
+        return 1;
+    }
+}

--- a/src/Gdpr/Preset/GtagLoaderScript.php
+++ b/src/Gdpr/Preset/GtagLoaderScript.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Preset;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+
+final class GtagLoaderScript implements TrackingScriptInterface
+{
+    public function __construct(
+        private readonly string $trackingId,
+        private readonly string $categoryKey = 'analytics',
+    ) {
+    }
+
+    public function getHandle(): string
+    {
+        return 'gtag-loader';
+    }
+
+    public function getCategoryKey(): string
+    {
+        return $this->categoryKey;
+    }
+
+    public function getSource(): string
+    {
+        return 'https://www.googletagmanager.com/gtag/js?id=' . $this->trackingId;
+    }
+
+    public function isInline(): bool
+    {
+        return false;
+    }
+
+    public function getLocation(): string
+    {
+        return 'head';
+    }
+
+    public function getPriority(): int
+    {
+        return 4;
+    }
+}

--- a/src/Gdpr/Preset/HotjarScript.php
+++ b/src/Gdpr/Preset/HotjarScript.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Preset;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+
+final class HotjarScript implements TrackingScriptInterface
+{
+    public function __construct(
+        private readonly string $siteId,
+    ) {
+    }
+
+    public function getHandle(): string
+    {
+        return 'hotjar';
+    }
+
+    public function getCategoryKey(): string
+    {
+        return 'analytics';
+    }
+
+    public function getSource(): string
+    {
+        return "(function(h,o,t,j,a,r){h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};"
+            . "h._hjSettings={hjid:" . $this->siteId . ",hjsv:6};"
+            . "a=o.getElementsByTagName('head')[0];"
+            . "r=o.createElement('script');r.async=1;"
+            . "r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;"
+            . "a.appendChild(r);"
+            . "})(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');";
+    }
+
+    public function isInline(): bool
+    {
+        return true;
+    }
+
+    public function getLocation(): string
+    {
+        return 'head';
+    }
+
+    public function getPriority(): int
+    {
+        return 10;
+    }
+}

--- a/src/Gdpr/Preset/HubSpotScript.php
+++ b/src/Gdpr/Preset/HubSpotScript.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Preset;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+
+final class HubSpotScript implements TrackingScriptInterface
+{
+    public function __construct(
+        private readonly string $portalId,
+    ) {
+    }
+
+    public function getHandle(): string
+    {
+        return 'hubspot';
+    }
+
+    public function getCategoryKey(): string
+    {
+        return 'marketing';
+    }
+
+    public function getSource(): string
+    {
+        return 'https://js.hs-scripts.com/' . $this->portalId . '.js';
+    }
+
+    public function isInline(): bool
+    {
+        return false;
+    }
+
+    public function getLocation(): string
+    {
+        return 'footer';
+    }
+
+    public function getPriority(): int
+    {
+        return 10;
+    }
+}

--- a/src/Gdpr/RegisterGdpr.php
+++ b/src/Gdpr/RegisterGdpr.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr;
+
+use BackTo\Framework\Contracts\HookDispatcherInterface;
+use BackTo\Framework\Contracts\Hooks;
+use BackTo\Framework\Gdpr\Contracts\ConsentStorageInterface;
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+
+class RegisterGdpr implements Hooks
+{
+    public function __construct(
+        private readonly ConsentCategoryRegistry $categoryRegistry,
+        private readonly TrackingScriptRegistry $scriptRegistry,
+        private readonly ConsentStorageInterface $consentStorage,
+        private readonly HookDispatcherInterface $hookDispatcher,
+        private readonly ConsentBanner $consentBanner,
+    ) {
+    }
+
+    public function hooks(): void
+    {
+        $this->hookDispatcher->addAction('wp_head', [$this, 'renderHeadScripts'], 1);
+        $this->hookDispatcher->addAction('wp_footer', [$this, 'renderFooterScripts'], 50);
+        $this->hookDispatcher->addAction('wp_footer', [$this, 'renderConsentBanner'], 100);
+    }
+
+    public function renderHeadScripts(): void
+    {
+        $this->renderScriptsForLocation('head');
+    }
+
+    public function renderFooterScripts(): void
+    {
+        $this->renderScriptsForLocation('footer');
+    }
+
+    public function renderConsentBanner(): void
+    {
+        echo $this->consentBanner->render();
+    }
+
+    private function renderScriptsForLocation(string $location): void
+    {
+        $scripts = $this->scriptRegistry->getScripts();
+
+        usort($scripts, static fn (TrackingScriptInterface $a, TrackingScriptInterface $b): int => $a->getPriority() <=> $b->getPriority());
+
+        foreach ($scripts as $script) {
+            if ($script->getLocation() !== $location) {
+                continue;
+            }
+
+            if (!$this->isScriptAllowed($script)) {
+                continue;
+            }
+
+            $this->outputScript($script);
+        }
+    }
+
+    private function isScriptAllowed(TrackingScriptInterface $script): bool
+    {
+        $category = $this->categoryRegistry->get($script->getCategoryKey());
+
+        if ($category !== null && $category->isRequired()) {
+            return true;
+        }
+
+        return $this->consentStorage->hasConsent($script->getCategoryKey());
+    }
+
+    private function outputScript(TrackingScriptInterface $script): void
+    {
+        if ($script->isInline()) {
+            echo '<script>' . $script->getSource() . '</script>' . "\n";
+        } else {
+            echo '<script src="' . htmlspecialchars($script->getSource(), ENT_QUOTES, 'UTF-8') . '"></script>' . "\n";
+        }
+    }
+}

--- a/src/Gdpr/Tests/ConsentBannerTest.php
+++ b/src/Gdpr/Tests/ConsentBannerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests;
+
+use BackTo\Framework\Gdpr\ConsentBanner;
+use BackTo\Framework\Gdpr\ConsentCategoryRegistry;
+use BackTo\Framework\Gdpr\Contracts\ConsentStorageInterface;
+use BackTo\Framework\Gdpr\Entity\ConsentCategory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ConsentBannerTest extends TestCase
+{
+    private ConsentCategoryRegistry $categoryRegistry;
+    private ConsentStorageInterface&MockObject $consentStorage;
+    private ConsentBanner $banner;
+
+    protected function setUp(): void
+    {
+        $this->categoryRegistry = new ConsentCategoryRegistry();
+        $this->consentStorage = $this->createMock(ConsentStorageInterface::class);
+        $this->banner = new ConsentBanner($this->categoryRegistry, $this->consentStorage);
+    }
+
+    public function testRenderReturnsEmptyStringWithNoCategories(): void
+    {
+        $this->consentStorage->method('isConsentGiven')->willReturn(false);
+        $this->consentStorage->method('getConsent')->willReturn([]);
+
+        $this->assertSame('', $this->banner->render());
+    }
+
+    public function testRenderContainsCategoryLabels(): void
+    {
+        $this->categoryRegistry->add(new ConsentCategory('analytics', 'Analytique', 'Mesure'));
+        $this->categoryRegistry->add(new ConsentCategory('marketing', 'Marketing', 'Publicite'));
+
+        $this->consentStorage->method('isConsentGiven')->willReturn(false);
+        $this->consentStorage->method('getConsent')->willReturn([]);
+
+        $html = $this->banner->render();
+
+        $this->assertStringContainsString('Analytique', $html);
+        $this->assertStringContainsString('Marketing', $html);
+        $this->assertStringContainsString('Mesure', $html);
+        $this->assertStringContainsString('Publicite', $html);
+    }
+
+    public function testRenderContainsThreeButtons(): void
+    {
+        $this->categoryRegistry->add(new ConsentCategory('analytics', 'Analytique'));
+
+        $this->consentStorage->method('isConsentGiven')->willReturn(false);
+        $this->consentStorage->method('getConsent')->willReturn([]);
+
+        $html = $this->banner->render();
+
+        $this->assertStringContainsString('Tout accepter', $html);
+        $this->assertStringContainsString('Tout refuser', $html);
+        $this->assertStringContainsString('Enregistrer mes choix', $html);
+    }
+
+    public function testRequiredCategoryHasDisabledCheckbox(): void
+    {
+        $this->categoryRegistry->add(new ConsentCategory('necessary', 'Necessaire', '', true));
+
+        $this->consentStorage->method('isConsentGiven')->willReturn(false);
+        $this->consentStorage->method('getConsent')->willReturn([]);
+
+        $html = $this->banner->render();
+
+        $this->assertStringContainsString('disabled', $html);
+        $this->assertStringContainsString('checked', $html);
+    }
+
+    public function testNonRequiredCategoryHasNoDisabledAttribute(): void
+    {
+        $this->categoryRegistry->add(new ConsentCategory('marketing', 'Marketing'));
+
+        $this->consentStorage->method('isConsentGiven')->willReturn(false);
+        $this->consentStorage->method('getConsent')->willReturn([]);
+
+        $html = $this->banner->render();
+
+        $this->assertStringContainsString('id="gdpr-cat-marketing"', $html);
+        // The checkbox should not have disabled attribute
+        $this->assertDoesNotMatchRegularExpression('/gdpr-cat-marketing[^>]*disabled/', $html);
+    }
+
+    public function testRenderContainsCookieJavaScript(): void
+    {
+        $this->categoryRegistry->add(new ConsentCategory('analytics', 'Analytique'));
+
+        $this->consentStorage->method('isConsentGiven')->willReturn(false);
+        $this->consentStorage->method('getConsent')->willReturn([]);
+
+        $html = $this->banner->render();
+
+        $this->assertStringContainsString('gdpr_consent', $html);
+        $this->assertStringContainsString('setCookie', $html);
+        $this->assertStringContainsString('saveConsent', $html);
+    }
+
+    public function testRenderContainsToggleButton(): void
+    {
+        $this->categoryRegistry->add(new ConsentCategory('analytics', 'Analytique'));
+
+        $this->consentStorage->method('isConsentGiven')->willReturn(false);
+        $this->consentStorage->method('getConsent')->willReturn([]);
+
+        $html = $this->banner->render();
+
+        $this->assertStringContainsString('gdpr-consent-toggle', $html);
+        $this->assertStringContainsString('Gerer les cookies', $html);
+    }
+}

--- a/src/Gdpr/Tests/ConsentCategoryRegistryTest.php
+++ b/src/Gdpr/Tests/ConsentCategoryRegistryTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests;
+
+use BackTo\Framework\Contracts\RegistryInterface;
+use BackTo\Framework\Gdpr\ConsentCategoryRegistry;
+use BackTo\Framework\Gdpr\Contracts\ConsentCategoryInterface;
+use BackTo\Framework\Gdpr\Entity\ConsentCategory;
+use PHPUnit\Framework\TestCase;
+
+class ConsentCategoryRegistryTest extends TestCase
+{
+    public function testImplementsRegistryInterface(): void
+    {
+        $registry = new ConsentCategoryRegistry();
+        $this->assertInstanceOf(RegistryInterface::class, $registry);
+    }
+
+    public function testEmptyRegistry(): void
+    {
+        $registry = new ConsentCategoryRegistry();
+        $this->assertCount(0, $registry->getCategories());
+    }
+
+    public function testAddCategories(): void
+    {
+        $registry = new ConsentCategoryRegistry();
+
+        $analytics = new ConsentCategory('analytics', 'Analytique');
+        $marketing = new ConsentCategory('marketing', 'Marketing');
+
+        $registry->add($analytics);
+        $registry->add($marketing);
+
+        $this->assertCount(2, $registry->getCategories());
+    }
+
+    public function testGetByKey(): void
+    {
+        $registry = new ConsentCategoryRegistry();
+        $analytics = new ConsentCategory('analytics', 'Analytique');
+        $registry->add($analytics);
+
+        $result = $registry->get('analytics');
+
+        $this->assertInstanceOf(ConsentCategoryInterface::class, $result);
+        $this->assertSame('analytics', $result->getKey());
+    }
+
+    public function testGetByKeyReturnsNullForUnknownKey(): void
+    {
+        $registry = new ConsentCategoryRegistry();
+        $this->assertNull($registry->get('unknown'));
+    }
+
+    public function testFluentInterface(): void
+    {
+        $registry = new ConsentCategoryRegistry();
+        $result = $registry->add(new ConsentCategory('a', 'A'));
+
+        $this->assertSame($registry, $result);
+    }
+}

--- a/src/Gdpr/Tests/CookieConsentStorageTest.php
+++ b/src/Gdpr/Tests/CookieConsentStorageTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests;
+
+use BackTo\Framework\Gdpr\Contracts\ConsentStorageInterface;
+use BackTo\Framework\Gdpr\Infrastructure\CookieConsentStorage;
+use PHPUnit\Framework\TestCase;
+
+class CookieConsentStorageTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        unset($_COOKIE['gdpr_consent']);
+    }
+
+    public function testImplementsInterface(): void
+    {
+        $storage = new CookieConsentStorage();
+        $this->assertInstanceOf(ConsentStorageInterface::class, $storage);
+    }
+
+    public function testGetConsentWithoutCookie(): void
+    {
+        $storage = new CookieConsentStorage();
+        $this->assertSame([], $storage->getConsent());
+    }
+
+    public function testIsConsentGivenWithoutCookie(): void
+    {
+        $storage = new CookieConsentStorage();
+        $this->assertFalse($storage->isConsentGiven());
+    }
+
+    public function testGetConsentWithValidCookie(): void
+    {
+        $_COOKIE['gdpr_consent'] = json_encode(['analytics' => true, 'marketing' => false]);
+
+        $storage = new CookieConsentStorage();
+        $consent = $storage->getConsent();
+
+        $this->assertTrue($consent['analytics']);
+        $this->assertFalse($consent['marketing']);
+    }
+
+    public function testHasConsentTrue(): void
+    {
+        $_COOKIE['gdpr_consent'] = json_encode(['analytics' => true]);
+
+        $storage = new CookieConsentStorage();
+        $this->assertTrue($storage->hasConsent('analytics'));
+    }
+
+    public function testHasConsentFalse(): void
+    {
+        $_COOKIE['gdpr_consent'] = json_encode(['analytics' => false]);
+
+        $storage = new CookieConsentStorage();
+        $this->assertFalse($storage->hasConsent('analytics'));
+    }
+
+    public function testHasConsentForMissingKey(): void
+    {
+        $_COOKIE['gdpr_consent'] = json_encode(['analytics' => true]);
+
+        $storage = new CookieConsentStorage();
+        $this->assertFalse($storage->hasConsent('marketing'));
+    }
+
+    public function testIsConsentGivenWithCookie(): void
+    {
+        $_COOKIE['gdpr_consent'] = json_encode(['analytics' => true]);
+
+        $storage = new CookieConsentStorage();
+        $this->assertTrue($storage->isConsentGiven());
+    }
+
+    public function testGetConsentWithInvalidJson(): void
+    {
+        $_COOKIE['gdpr_consent'] = 'invalid-json';
+
+        $storage = new CookieConsentStorage();
+        $this->assertSame([], $storage->getConsent());
+    }
+}

--- a/src/Gdpr/Tests/Entity/ConsentCategoryTest.php
+++ b/src/Gdpr/Tests/Entity/ConsentCategoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests\Entity;
+
+use BackTo\Framework\Gdpr\Contracts\ConsentCategoryInterface;
+use BackTo\Framework\Gdpr\Entity\ConsentCategory;
+use PHPUnit\Framework\TestCase;
+
+class ConsentCategoryTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $category = new ConsentCategory('analytics', 'Analytique');
+        $this->assertInstanceOf(ConsentCategoryInterface::class, $category);
+    }
+
+    public function testGetters(): void
+    {
+        $category = new ConsentCategory('analytics', 'Analytique', 'Mesure d\'audience', false);
+
+        $this->assertSame('analytics', $category->getKey());
+        $this->assertSame('Analytique', $category->getLabel());
+        $this->assertSame('Mesure d\'audience', $category->getDescription());
+        $this->assertFalse($category->isRequired());
+    }
+
+    public function testRequiredCategory(): void
+    {
+        $category = new ConsentCategory('necessary', 'Necessaire', 'Cookies essentiels', true);
+
+        $this->assertTrue($category->isRequired());
+    }
+
+    public function testDefaultValues(): void
+    {
+        $category = new ConsentCategory('marketing', 'Marketing');
+
+        $this->assertSame('', $category->getDescription());
+        $this->assertFalse($category->isRequired());
+    }
+}

--- a/src/Gdpr/Tests/Entity/TrackingScriptTest.php
+++ b/src/Gdpr/Tests/Entity/TrackingScriptTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests\Entity;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+use BackTo\Framework\Gdpr\Entity\TrackingScript;
+use PHPUnit\Framework\TestCase;
+
+class TrackingScriptTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $script = new TrackingScript('ga', 'analytics', 'https://example.com/ga.js');
+        $this->assertInstanceOf(TrackingScriptInterface::class, $script);
+    }
+
+    public function testGetters(): void
+    {
+        $script = new TrackingScript('ga', 'analytics', 'https://example.com/ga.js', false, 'footer', 20);
+
+        $this->assertSame('ga', $script->getHandle());
+        $this->assertSame('analytics', $script->getCategoryKey());
+        $this->assertSame('https://example.com/ga.js', $script->getSource());
+        $this->assertFalse($script->isInline());
+        $this->assertSame('footer', $script->getLocation());
+        $this->assertSame(20, $script->getPriority());
+    }
+
+    public function testInlineScript(): void
+    {
+        $script = new TrackingScript('gtag-config', 'analytics', "gtag('config', 'G-XXX');", true);
+
+        $this->assertTrue($script->isInline());
+        $this->assertSame("gtag('config', 'G-XXX');", $script->getSource());
+    }
+
+    public function testDefaultValues(): void
+    {
+        $script = new TrackingScript('pixel', 'marketing', 'https://example.com/pixel.js');
+
+        $this->assertFalse($script->isInline());
+        $this->assertSame('head', $script->getLocation());
+        $this->assertSame(10, $script->getPriority());
+    }
+}

--- a/src/Gdpr/Tests/Preset/GoogleAdsScriptTest.php
+++ b/src/Gdpr/Tests/Preset/GoogleAdsScriptTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests\Preset;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+use BackTo\Framework\Gdpr\Preset\GoogleAdsScript;
+use PHPUnit\Framework\TestCase;
+
+class GoogleAdsScriptTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $script = new GoogleAdsScript('AW-XXXX');
+        $this->assertInstanceOf(TrackingScriptInterface::class, $script);
+    }
+
+    public function testHandle(): void
+    {
+        $script = new GoogleAdsScript('AW-XXXX');
+        $this->assertSame('google-ads', $script->getHandle());
+    }
+
+    public function testCategoryKey(): void
+    {
+        $script = new GoogleAdsScript('AW-XXXX');
+        $this->assertSame('marketing', $script->getCategoryKey());
+    }
+
+    public function testSourceContainsConversionId(): void
+    {
+        $script = new GoogleAdsScript('AW-123456');
+        $source = $script->getSource();
+        $this->assertStringContainsString('AW-123456', $source);
+        $this->assertStringContainsString('gtag', $source);
+    }
+
+    public function testIsInline(): void
+    {
+        $script = new GoogleAdsScript('AW-XXXX');
+        $this->assertTrue($script->isInline());
+    }
+
+    public function testLocation(): void
+    {
+        $script = new GoogleAdsScript('AW-XXXX');
+        $this->assertSame('head', $script->getLocation());
+    }
+
+    public function testPriority(): void
+    {
+        $script = new GoogleAdsScript('AW-XXXX');
+        $this->assertSame(5, $script->getPriority());
+    }
+}

--- a/src/Gdpr/Tests/Preset/GoogleAnalyticsScriptTest.php
+++ b/src/Gdpr/Tests/Preset/GoogleAnalyticsScriptTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests\Preset;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+use BackTo\Framework\Gdpr\Preset\GoogleAnalyticsScript;
+use PHPUnit\Framework\TestCase;
+
+class GoogleAnalyticsScriptTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $script = new GoogleAnalyticsScript('G-XXXX');
+        $this->assertInstanceOf(TrackingScriptInterface::class, $script);
+    }
+
+    public function testHandle(): void
+    {
+        $script = new GoogleAnalyticsScript('G-XXXX');
+        $this->assertSame('google-analytics', $script->getHandle());
+    }
+
+    public function testCategoryKey(): void
+    {
+        $script = new GoogleAnalyticsScript('G-XXXX');
+        $this->assertSame('analytics', $script->getCategoryKey());
+    }
+
+    public function testSourceContainsMeasurementId(): void
+    {
+        $script = new GoogleAnalyticsScript('G-ABC123');
+        $source = $script->getSource();
+        $this->assertStringContainsString('G-ABC123', $source);
+        $this->assertStringContainsString('gtag', $source);
+    }
+
+    public function testIsInline(): void
+    {
+        $script = new GoogleAnalyticsScript('G-XXXX');
+        $this->assertTrue($script->isInline());
+    }
+
+    public function testLocation(): void
+    {
+        $script = new GoogleAnalyticsScript('G-XXXX');
+        $this->assertSame('head', $script->getLocation());
+    }
+
+    public function testPriority(): void
+    {
+        $script = new GoogleAnalyticsScript('G-XXXX');
+        $this->assertSame(5, $script->getPriority());
+    }
+}

--- a/src/Gdpr/Tests/Preset/GoogleTagManagerScriptTest.php
+++ b/src/Gdpr/Tests/Preset/GoogleTagManagerScriptTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests\Preset;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+use BackTo\Framework\Gdpr\Preset\GoogleTagManagerScript;
+use PHPUnit\Framework\TestCase;
+
+class GoogleTagManagerScriptTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $script = new GoogleTagManagerScript('GTM-XXXX');
+        $this->assertInstanceOf(TrackingScriptInterface::class, $script);
+    }
+
+    public function testHandle(): void
+    {
+        $script = new GoogleTagManagerScript('GTM-XXXX');
+        $this->assertSame('google-tag-manager', $script->getHandle());
+    }
+
+    public function testCategoryKey(): void
+    {
+        $script = new GoogleTagManagerScript('GTM-XXXX');
+        $this->assertSame('analytics', $script->getCategoryKey());
+    }
+
+    public function testSourceContainsContainerId(): void
+    {
+        $script = new GoogleTagManagerScript('GTM-ABC123');
+        $this->assertStringContainsString('GTM-ABC123', $script->getSource());
+        $this->assertStringContainsString('googletagmanager.com/gtm.js', $script->getSource());
+    }
+
+    public function testIsInline(): void
+    {
+        $script = new GoogleTagManagerScript('GTM-XXXX');
+        $this->assertTrue($script->isInline());
+    }
+
+    public function testLocation(): void
+    {
+        $script = new GoogleTagManagerScript('GTM-XXXX');
+        $this->assertSame('head', $script->getLocation());
+    }
+
+    public function testPriority(): void
+    {
+        $script = new GoogleTagManagerScript('GTM-XXXX');
+        $this->assertSame(1, $script->getPriority());
+    }
+}

--- a/src/Gdpr/Tests/Preset/GtagLoaderScriptTest.php
+++ b/src/Gdpr/Tests/Preset/GtagLoaderScriptTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests\Preset;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+use BackTo\Framework\Gdpr\Preset\GtagLoaderScript;
+use PHPUnit\Framework\TestCase;
+
+class GtagLoaderScriptTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $script = new GtagLoaderScript('G-XXXX');
+        $this->assertInstanceOf(TrackingScriptInterface::class, $script);
+    }
+
+    public function testHandle(): void
+    {
+        $script = new GtagLoaderScript('G-XXXX');
+        $this->assertSame('gtag-loader', $script->getHandle());
+    }
+
+    public function testDefaultCategoryKey(): void
+    {
+        $script = new GtagLoaderScript('G-XXXX');
+        $this->assertSame('analytics', $script->getCategoryKey());
+    }
+
+    public function testCustomCategoryKey(): void
+    {
+        $script = new GtagLoaderScript('AW-XXXX', 'marketing');
+        $this->assertSame('marketing', $script->getCategoryKey());
+    }
+
+    public function testSourceContainsTrackingId(): void
+    {
+        $script = new GtagLoaderScript('G-ABC123');
+        $source = $script->getSource();
+        $this->assertSame('https://www.googletagmanager.com/gtag/js?id=G-ABC123', $source);
+    }
+
+    public function testIsNotInline(): void
+    {
+        $script = new GtagLoaderScript('G-XXXX');
+        $this->assertFalse($script->isInline());
+    }
+
+    public function testLocation(): void
+    {
+        $script = new GtagLoaderScript('G-XXXX');
+        $this->assertSame('head', $script->getLocation());
+    }
+
+    public function testPriority(): void
+    {
+        $script = new GtagLoaderScript('G-XXXX');
+        $this->assertSame(4, $script->getPriority());
+    }
+}

--- a/src/Gdpr/Tests/Preset/HotjarScriptTest.php
+++ b/src/Gdpr/Tests/Preset/HotjarScriptTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests\Preset;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+use BackTo\Framework\Gdpr\Preset\HotjarScript;
+use PHPUnit\Framework\TestCase;
+
+class HotjarScriptTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $script = new HotjarScript('123456');
+        $this->assertInstanceOf(TrackingScriptInterface::class, $script);
+    }
+
+    public function testHandle(): void
+    {
+        $script = new HotjarScript('123456');
+        $this->assertSame('hotjar', $script->getHandle());
+    }
+
+    public function testCategoryKey(): void
+    {
+        $script = new HotjarScript('123456');
+        $this->assertSame('analytics', $script->getCategoryKey());
+    }
+
+    public function testSourceContainsSiteId(): void
+    {
+        $script = new HotjarScript('987654');
+        $source = $script->getSource();
+        $this->assertStringContainsString('987654', $source);
+        $this->assertStringContainsString('static.hotjar.com', $source);
+    }
+
+    public function testIsInline(): void
+    {
+        $script = new HotjarScript('123456');
+        $this->assertTrue($script->isInline());
+    }
+
+    public function testLocation(): void
+    {
+        $script = new HotjarScript('123456');
+        $this->assertSame('head', $script->getLocation());
+    }
+
+    public function testPriority(): void
+    {
+        $script = new HotjarScript('123456');
+        $this->assertSame(10, $script->getPriority());
+    }
+}

--- a/src/Gdpr/Tests/Preset/HubSpotScriptTest.php
+++ b/src/Gdpr/Tests/Preset/HubSpotScriptTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests\Preset;
+
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+use BackTo\Framework\Gdpr\Preset\HubSpotScript;
+use PHPUnit\Framework\TestCase;
+
+class HubSpotScriptTest extends TestCase
+{
+    public function testImplementsInterface(): void
+    {
+        $script = new HubSpotScript('12345678');
+        $this->assertInstanceOf(TrackingScriptInterface::class, $script);
+    }
+
+    public function testHandle(): void
+    {
+        $script = new HubSpotScript('12345678');
+        $this->assertSame('hubspot', $script->getHandle());
+    }
+
+    public function testCategoryKey(): void
+    {
+        $script = new HubSpotScript('12345678');
+        $this->assertSame('marketing', $script->getCategoryKey());
+    }
+
+    public function testSourceContainsPortalId(): void
+    {
+        $script = new HubSpotScript('99887766');
+        $source = $script->getSource();
+        $this->assertStringContainsString('99887766', $source);
+        $this->assertStringContainsString('js.hs-scripts.com', $source);
+    }
+
+    public function testIsNotInline(): void
+    {
+        $script = new HubSpotScript('12345678');
+        $this->assertFalse($script->isInline());
+    }
+
+    public function testLocation(): void
+    {
+        $script = new HubSpotScript('12345678');
+        $this->assertSame('footer', $script->getLocation());
+    }
+
+    public function testPriority(): void
+    {
+        $script = new HubSpotScript('12345678');
+        $this->assertSame(10, $script->getPriority());
+    }
+}

--- a/src/Gdpr/Tests/RegisterGdprTest.php
+++ b/src/Gdpr/Tests/RegisterGdprTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests;
+
+use BackTo\Framework\Contracts\HookDispatcherInterface;
+use BackTo\Framework\Gdpr\ConsentBanner;
+use BackTo\Framework\Gdpr\ConsentCategoryRegistry;
+use BackTo\Framework\Gdpr\Contracts\ConsentStorageInterface;
+use BackTo\Framework\Gdpr\Entity\ConsentCategory;
+use BackTo\Framework\Gdpr\Entity\TrackingScript;
+use BackTo\Framework\Gdpr\RegisterGdpr;
+use BackTo\Framework\Gdpr\TrackingScriptRegistry;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class RegisterGdprTest extends TestCase
+{
+    private ConsentCategoryRegistry $categoryRegistry;
+    private TrackingScriptRegistry $scriptRegistry;
+    private ConsentStorageInterface&MockObject $consentStorage;
+    private HookDispatcherInterface&MockObject $hookDispatcher;
+    private ConsentBanner&MockObject $consentBanner;
+    private RegisterGdpr $registerGdpr;
+
+    protected function setUp(): void
+    {
+        $this->categoryRegistry = new ConsentCategoryRegistry();
+        $this->scriptRegistry = new TrackingScriptRegistry();
+        $this->consentStorage = $this->createMock(ConsentStorageInterface::class);
+        $this->hookDispatcher = $this->createMock(HookDispatcherInterface::class);
+        $this->consentBanner = $this->createMock(ConsentBanner::class);
+
+        $this->registerGdpr = new RegisterGdpr(
+            $this->categoryRegistry,
+            $this->scriptRegistry,
+            $this->consentStorage,
+            $this->hookDispatcher,
+            $this->consentBanner,
+        );
+    }
+
+    public function testHooksRegistersThreeActions(): void
+    {
+        $this->hookDispatcher->expects($this->exactly(3))
+            ->method('addAction')
+            ->willReturnCallback(function (string $hook): void {
+                $this->assertContains($hook, ['wp_head', 'wp_footer']);
+            });
+
+        $this->registerGdpr->hooks();
+    }
+
+    public function testRenderHeadScriptsOutputsAllowedScripts(): void
+    {
+        $this->categoryRegistry->add(new ConsentCategory('analytics', 'Analytique'));
+        $this->scriptRegistry->add(new TrackingScript('ga', 'analytics', "console.log('ga');", true, 'head'));
+
+        $this->consentStorage->method('hasConsent')
+            ->with('analytics')
+            ->willReturn(true);
+
+        ob_start();
+        $this->registerGdpr->renderHeadScripts();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString("console.log('ga');", $output);
+    }
+
+    public function testRenderHeadScriptsBlocksNonConsentedScripts(): void
+    {
+        $this->categoryRegistry->add(new ConsentCategory('marketing', 'Marketing'));
+        $this->scriptRegistry->add(new TrackingScript('pixel', 'marketing', "console.log('pixel');", true, 'head'));
+
+        $this->consentStorage->method('hasConsent')
+            ->with('marketing')
+            ->willReturn(false);
+
+        ob_start();
+        $this->registerGdpr->renderHeadScripts();
+        $output = ob_get_clean();
+
+        $this->assertEmpty($output);
+    }
+
+    public function testRequiredCategoryScriptsAlwaysLoad(): void
+    {
+        $this->categoryRegistry->add(new ConsentCategory('necessary', 'Necessaire', '', true));
+        $this->scriptRegistry->add(new TrackingScript('essential', 'necessary', "console.log('ok');", true, 'head'));
+
+        $this->consentStorage->method('hasConsent')->willReturn(false);
+
+        ob_start();
+        $this->registerGdpr->renderHeadScripts();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString("console.log('ok');", $output);
+    }
+
+    public function testRenderFooterScriptsOnlyOutputsFooterLocation(): void
+    {
+        $this->categoryRegistry->add(new ConsentCategory('analytics', 'Analytique'));
+        $this->scriptRegistry->add(new TrackingScript('head-script', 'analytics', "head();", true, 'head'));
+        $this->scriptRegistry->add(new TrackingScript('footer-script', 'analytics', "footer();", true, 'footer'));
+
+        $this->consentStorage->method('hasConsent')->willReturn(true);
+
+        ob_start();
+        $this->registerGdpr->renderFooterScripts();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('footer();', $output);
+        $this->assertStringNotContainsString('head();', $output);
+    }
+
+    public function testExternalScriptRendersWithSrcAttribute(): void
+    {
+        $this->categoryRegistry->add(new ConsentCategory('analytics', 'Analytique'));
+        $this->scriptRegistry->add(new TrackingScript('ga', 'analytics', 'https://example.com/ga.js', false, 'head'));
+
+        $this->consentStorage->method('hasConsent')->willReturn(true);
+
+        ob_start();
+        $this->registerGdpr->renderHeadScripts();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('src="https://example.com/ga.js"', $output);
+    }
+
+    public function testRenderConsentBannerDelegatesToBanner(): void
+    {
+        $this->consentBanner->expects($this->once())
+            ->method('render')
+            ->willReturn('<div>banner</div>');
+
+        ob_start();
+        $this->registerGdpr->renderConsentBanner();
+        $output = ob_get_clean();
+
+        $this->assertSame('<div>banner</div>', $output);
+    }
+}

--- a/src/Gdpr/Tests/TrackingScriptRegistryTest.php
+++ b/src/Gdpr/Tests/TrackingScriptRegistryTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr\Tests;
+
+use BackTo\Framework\Contracts\RegistryInterface;
+use BackTo\Framework\Gdpr\Entity\TrackingScript;
+use BackTo\Framework\Gdpr\TrackingScriptRegistry;
+use PHPUnit\Framework\TestCase;
+
+class TrackingScriptRegistryTest extends TestCase
+{
+    public function testImplementsRegistryInterface(): void
+    {
+        $registry = new TrackingScriptRegistry();
+        $this->assertInstanceOf(RegistryInterface::class, $registry);
+    }
+
+    public function testEmptyRegistry(): void
+    {
+        $registry = new TrackingScriptRegistry();
+        $this->assertCount(0, $registry->getScripts());
+    }
+
+    public function testAddScripts(): void
+    {
+        $registry = new TrackingScriptRegistry();
+
+        $registry->add(new TrackingScript('ga', 'analytics', 'https://example.com/ga.js'));
+        $registry->add(new TrackingScript('pixel', 'marketing', 'https://example.com/pixel.js'));
+
+        $this->assertCount(2, $registry->getScripts());
+    }
+
+    public function testGetScriptsByCategory(): void
+    {
+        $registry = new TrackingScriptRegistry();
+
+        $registry->add(new TrackingScript('ga', 'analytics', 'https://example.com/ga.js'));
+        $registry->add(new TrackingScript('gtag', 'analytics', "gtag('config');", true));
+        $registry->add(new TrackingScript('pixel', 'marketing', 'https://example.com/pixel.js'));
+
+        $analyticsScripts = $registry->getScriptsByCategory('analytics');
+        $marketingScripts = $registry->getScriptsByCategory('marketing');
+
+        $this->assertCount(2, $analyticsScripts);
+        $this->assertCount(1, $marketingScripts);
+    }
+
+    public function testGetScriptsByCategoryReturnsEmptyForUnknown(): void
+    {
+        $registry = new TrackingScriptRegistry();
+        $this->assertCount(0, $registry->getScriptsByCategory('unknown'));
+    }
+
+    public function testFluentInterface(): void
+    {
+        $registry = new TrackingScriptRegistry();
+        $result = $registry->add(new TrackingScript('ga', 'analytics', 'https://example.com/ga.js'));
+
+        $this->assertSame($registry, $result);
+    }
+}

--- a/src/Gdpr/TrackingScriptRegistry.php
+++ b/src/Gdpr/TrackingScriptRegistry.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Gdpr;
+
+use BackTo\Framework\Contracts\RegistryInterface;
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptInterface;
+use BackTo\Framework\Gdpr\Contracts\TrackingScriptRegistryInterface;
+
+class TrackingScriptRegistry implements RegistryInterface, TrackingScriptRegistryInterface
+{
+    /** @var TrackingScriptInterface[] */
+    private array $scripts = [];
+
+    public function add(TrackingScriptInterface $script): TrackingScriptRegistryInterface
+    {
+        $this->scripts[] = $script;
+
+        return $this;
+    }
+
+    /**
+     * @return TrackingScriptInterface[]
+     */
+    public function getScripts(): array
+    {
+        return $this->scripts;
+    }
+
+    /**
+     * @return TrackingScriptInterface[]
+     */
+    public function getScriptsByCategory(string $categoryKey): array
+    {
+        return array_values(
+            array_filter(
+                $this->scripts,
+                static fn (TrackingScriptInterface $script): bool => $script->getCategoryKey() === $categoryKey
+            )
+        );
+    }
+}


### PR DESCRIPTION
Add a new `src/Gdpr/` module following Clean Architecture and DDD patterns
to manage user consent and conditional tracking script loading.

Domain layer:
- ConsentCategoryInterface / TrackingScriptInterface contracts
- Immutable value objects (ConsentCategory, TrackingScript entities)
- In-memory registries (ConsentCategoryRegistry, TrackingScriptRegistry)

Application layer:
- RegisterGdpr orchestrator: hooks into wp_head/wp_footer to conditionally
  output scripts based on consent status
- ConsentBanner: renders a vanilla JS/CSS cookie consent banner with
  accept all / reject all / save preferences

Infrastructure layer:
- CookieConsentStorage adapter implementing ConsentStorageInterface
- DI compiler passes for auto-registration of tagged services
- Integration with WordPressExtension (autoconfiguration, compiler passes,
  port bindings) and WordPressContainer (bundle registration)

Developers can declare consent categories and tracking scripts either via
tagged PHP services (DI) or via configuration in services.php.

Includes 43 unit tests covering all layers, PHPStan level 8 clean.

https://claude.ai/code/session_012X4pSQVugRWJj9PWBb2xng