### PR TITLE
feat(seo): add schema.org JSON-LD structured data support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **SEO Schema**: `SchemaRef` value object for `@id` cross-referencing between nodes in a JSON-LD `@graph`
+- **SEO Schema**: `Schema::ref()` factory method for creating `@id` references
+- **SEO Schema**: `SchemaType::id()` method to set `@id` on any schema node
+- **SEO Schema**: Schema validation with `validate()` and `isValid()` methods — checks required properties per Google's rich results guidelines for Article, Product, Event, Course, JobPosting, VideoObject, FAQPage, Review, LocalBusiness, Offer
+- **SEO Schema**: `SchemaManager::validate()` to validate all registered schemas at once
+- **SEO Schema**: `PostTypeSchemaResolver` for mapping custom post types to schema generators
+- **SEO Schema**: `SeoConfig` class to load schema configuration from `config/seo.php` (post type map, disable plugin schema)
+- **SEO Schema**: Built-in generators (WebSite, Organization, Article) now use `@id` linking and `Schema::ref()` for a connected graph
+- **Documentation**: Schema structured data sections in SEO how-to and reference docs
 - **Admin module**: `AdminPageInterface`, `AdminPageRegistry`, `RegisterAdminPage` orchestrator, `WordPressAdminPageRegistrar` adapter
 - **Options module**: `OptionsRepositoryInterface` port with `WordPressOptionsRepository` adapter
 - **REST API module**: `RestRouteInterface`, `RestRouteRegistry`, `RegisterRestRoute` orchestrator, `WordPressRestRouteRegistrar` adapter

--- a/docs/how-to/integrate-seo.md
+++ b/docs/how-to/integrate-seo.md
@@ -95,3 +95,113 @@ Register it with the `SeoManager` via DI or manually:
 ```php
 $seoManager->addProvider(new RankMathProvider());
 ```
+
+## Add structured data (JSON-LD)
+
+The module includes a full schema.org system with a fluent API. Schemas are registered via the `SchemaManager` and rendered as a single JSON-LD `<script>` block.
+
+### Build a schema manually
+
+```php
+use BackTo\Framework\Seo\Schema;
+
+$article = Schema::article()
+    ->set('headline', 'My Article')
+    ->set('author', Schema::person()->set('name', 'John Doe'))
+    ->set('datePublished', '2026-01-15');
+
+$schemaManager->add($article);
+```
+
+### Link schemas with `@id`
+
+Use `Schema::ref()` to reference other nodes by `@id`, avoiding data duplication:
+
+```php
+$org = Schema::organization()
+    ->id('https://example.com/#organization')
+    ->set('name', 'Acme Corp');
+
+$article = Schema::article()
+    ->id('https://example.com/post/1#article')
+    ->set('headline', 'Hello World')
+    ->set('publisher', Schema::ref('https://example.com/#organization'));
+
+$schemaManager->add($org);
+$schemaManager->add($article);
+```
+
+This renders a `@graph` with linked nodes instead of duplicating the organization data in every article.
+
+### Validate schemas
+
+Concrete types define required properties per Google's rich results guidelines:
+
+```php
+$product = Schema::product()->set('name', 'Widget');
+$missing = $product->validate(); // ['image', 'offers']
+
+// Or validate all schemas at once:
+$errors = $schemaManager->validate();
+// ['Product' => ['image', 'offers']]
+```
+
+### Map custom post types to schema generators
+
+Create a `config/seo.php` file in your theme to map post types to generators:
+
+```php
+<?php
+
+// config/seo.php
+return [
+    'schema' => [
+        'post_type_map' => [
+            'post'      => \App\Seo\ArticleSchemaGenerator::class,
+            'formation' => \App\Seo\CourseSchemaGenerator::class,
+            'evenement' => \App\Seo\EventSchemaGenerator::class,
+        ],
+        'disable_plugin_schema' => true,
+    ],
+];
+```
+
+Each generator must implement a `generate(?int $postId): ?SchemaType` method:
+
+```php
+<?php
+
+namespace App\Seo;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class CourseSchemaGenerator
+{
+    public function generate(?int $postId = null): ?SchemaType
+    {
+        if ($postId === null) {
+            return null;
+        }
+
+        $post = get_post($postId);
+
+        return Schema::course()
+            ->set('name', $post->post_title)
+            ->set('description', get_the_excerpt($post))
+            ->set('provider', Schema::ref(get_site_url() . '/#organization'));
+    }
+}
+```
+
+### Disable plugin schema output
+
+By default, the framework disables the native schema output of Yoast SEO and SEOPress to avoid duplication. Control this via `config/seo.php`:
+
+```php
+return [
+    'schema' => [
+        'disable_plugin_schema' => false, // Keep plugin schema output
+    ],
+];
+```

--- a/docs/reference/modules/seo.md
+++ b/docs/reference/modules/seo.md
@@ -43,3 +43,125 @@ Methods: `getFacebookUrl`, `getTwitterUrl`, `getInstagramUrl`, `getLinkedInUrl`,
 ### `MetaProviderInterface`
 
 Methods: `getTitle`, `getDescription`, `getCanonicalUrl`, `getOgTitle`, `getOgDescription`, `getOgImageUrl` (all with optional `?int $postId`).
+
+## Schema (Structured Data)
+
+The SEO module includes a full JSON-LD structured data system based on schema.org.
+
+### `Schema` (static factory)
+
+Creates schema.org types via static methods:
+
+```php
+use BackTo\Framework\Seo\Schema;
+
+Schema::article();        // Article
+Schema::organization();   // Organization
+Schema::product();        // Product
+Schema::event();          // Event
+Schema::faqPage();        // FAQPage
+Schema::course();         // Course
+Schema::jobPosting();     // JobPosting
+Schema::videoObject();    // VideoObject
+Schema::localBusiness();  // LocalBusiness
+Schema::review();         // Review
+Schema::webSite();        // WebSite
+Schema::breadcrumbList(); // BreadcrumbList
+Schema::person();         // Person
+Schema::offer();          // Offer
+Schema::type('Custom');   // Any type by name
+Schema::ref('#id');       // @id reference (SchemaRef)
+```
+
+### `SchemaType` (base class)
+
+Fluent builder for all schema.org types:
+
+```php
+$article = Schema::article()
+    ->id('https://example.com/post/1#article')
+    ->set('headline', 'My Article')
+    ->set('author', Schema::person()->set('name', 'John'));
+```
+
+| Method | Description |
+|--------|-------------|
+| `set(string, mixed)` | Set any property |
+| `id(string)` | Set the `@id` for graph linking |
+| `toArray()` | Export as JSON-LD array |
+| `validate()` | Returns missing required properties |
+| `isValid()` | Whether all required properties are set |
+| `getType()` | Get the `@type` string |
+
+### `SchemaRef` (`@id` linking)
+
+References another schema node by `@id`, avoiding data duplication in a `@graph`:
+
+```php
+$org = Schema::organization()->id('https://example.com/#org')->set('name', 'Acme');
+$article = Schema::article()->set('publisher', Schema::ref('https://example.com/#org'));
+```
+
+Renders as `{"publisher": {"@id": "https://example.com/#org"}}`.
+
+### `SchemaManager`
+
+Central registry that collects schemas and renders a single JSON-LD `<script>` block:
+
+```php
+$manager->add(Schema::organization()->set('name', 'Acme'));
+$manager->add(Schema::article()->set('headline', 'Hello'));
+echo $manager->render(); // <script type="application/ld+json">...</script>
+```
+
+Uses `@graph` when multiple schemas are registered. Provides `validate()` to check all schemas at once.
+
+| Method | Description |
+|--------|-------------|
+| `add(SchemaType)` | Register a schema |
+| `render()` | Output JSON-LD `<script>` block |
+| `validate()` | Returns `array<type, missing[]>` for all schemas |
+| `hasSchemas()` | Whether any schemas are registered |
+| `getSchemas()` | Get all registered `SchemaType` instances |
+| `toArray()` | Export all schemas as arrays |
+
+### Schema validation
+
+Concrete types define required properties per Google's rich results guidelines. Call `validate()` to get missing properties:
+
+```php
+$article = Schema::article()->set('headline', 'Test');
+$missing = $article->validate(); // ['author', 'datePublished']
+```
+
+Types with validation: `Article`, `Product`, `Event`, `Course`, `JobPosting`, `VideoObject`, `FAQPage`, `Review`, `LocalBusiness`, `Offer`.
+
+### `PostTypeSchemaResolver` (CPT mapping)
+
+Maps WordPress post types to schema generators. Configured via `config/seo.php`:
+
+```php
+// config/seo.php
+return [
+    'schema' => [
+        'post_type_map' => [
+            'post'      => \App\Seo\ArticleSchemaGenerator::class,
+            'formation' => \App\Seo\CourseSchemaGenerator::class,
+        ],
+        'disable_plugin_schema' => true,
+    ],
+];
+```
+
+Each generator must implement a `generate(?int $postId): ?SchemaType` method.
+
+### `SeoConfig`
+
+Loads `config/seo.php` from the theme directory. Supports dot-notation access:
+
+| Method | Description |
+|--------|-------------|
+| `get(string $key, mixed $default)` | Dot-notation getter (e.g. `schema.post_type_map`) |
+| `getPostTypeMap()` | Returns the CPT → generator mapping |
+| `shouldDisablePluginSchema()` | Whether to disable plugin schema output (default: `true`) |
+| `all()` | Full config array |

--- a/src/Seo/Actions/DisablePluginSchema.php
+++ b/src/Seo/Actions/DisablePluginSchema.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Actions;
+
+use BackTo\Framework\Contracts\HookDispatcherInterface;
+use BackTo\Framework\Contracts\Hooks;
+use BackTo\Framework\Seo\SeoManager;
+
+/**
+ * Disable schema.org output from Yoast SEO and SEOPress to avoid duplicates
+ * when the framework generates its own structured data.
+ */
+class DisablePluginSchema implements Hooks
+{
+    private SeoManager $seoManager;
+
+    private HookDispatcherInterface $hookDispatcher;
+
+    public function __construct(SeoManager $seoManager, HookDispatcherInterface $hookDispatcher)
+    {
+        $this->seoManager = $seoManager;
+        $this->hookDispatcher = $hookDispatcher;
+    }
+
+    public function hooks(): void
+    {
+        if (!$this->seoManager->hasProvider()) {
+            return;
+        }
+
+        $provider = $this->seoManager->getProvider();
+
+        match ($provider->getName()) {
+            'yoast' => $this->disableYoastSchema(),
+            'seopress' => $this->disableSeoPressSchema(),
+            default => null,
+        };
+    }
+
+    private function disableYoastSchema(): void
+    {
+        $this->hookDispatcher->addFilter('wpseo_json_ld_output', '__return_empty_array');
+    }
+
+    private function disableSeoPressSchema(): void
+    {
+        $this->hookDispatcher->addFilter('seopress_schemas_auto_enabled', '__return_false');
+    }
+}

--- a/src/Seo/Actions/DisablePluginSchema.php
+++ b/src/Seo/Actions/DisablePluginSchema.php
@@ -6,26 +6,36 @@ namespace BackTo\Framework\Seo\Actions;
 
 use BackTo\Framework\Contracts\HookDispatcherInterface;
 use BackTo\Framework\Contracts\Hooks;
+use BackTo\Framework\Seo\SeoConfig;
 use BackTo\Framework\Seo\SeoManager;
 
 /**
  * Disable schema.org output from Yoast SEO and SEOPress to avoid duplicates
  * when the framework generates its own structured data.
+ *
+ * Can be disabled via config/seo.php: 'schema.disable_plugin_schema' => false
  */
 class DisablePluginSchema implements Hooks
 {
     private SeoManager $seoManager;
 
+    private SeoConfig $seoConfig;
+
     private HookDispatcherInterface $hookDispatcher;
 
-    public function __construct(SeoManager $seoManager, HookDispatcherInterface $hookDispatcher)
+    public function __construct(SeoManager $seoManager, SeoConfig $seoConfig, HookDispatcherInterface $hookDispatcher)
     {
         $this->seoManager = $seoManager;
+        $this->seoConfig = $seoConfig;
         $this->hookDispatcher = $hookDispatcher;
     }
 
     public function hooks(): void
     {
+        if (!$this->seoConfig->shouldDisablePluginSchema()) {
+            return;
+        }
+
         if (!$this->seoManager->hasProvider()) {
             return;
         }

--- a/src/Seo/Contracts/SchemaProviderInterface.php
+++ b/src/Seo/Contracts/SchemaProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Contracts;
+
+use BackTo\Framework\Seo\Schema\SchemaManager;
+
+/**
+ * Provides schema.org structured data from an SEO plugin.
+ *
+ * Implementations should register their schemas on the SchemaManager.
+ */
+interface SchemaProviderInterface
+{
+    /**
+     * Register schema.org structured data on the manager.
+     */
+    public function registerSchemas(SchemaManager $schemaManager): void;
+}

--- a/src/Seo/Hooks/AddSchemaToTimberContext.php
+++ b/src/Seo/Hooks/AddSchemaToTimberContext.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Hooks;
+
+use BackTo\Framework\Contracts\HookDispatcherInterface;
+use BackTo\Framework\Contracts\Hooks;
+use BackTo\Framework\Seo\Schema\SchemaManager;
+
+/**
+ * Add the SchemaManager to the Timber context for use in Twig templates.
+ *
+ * Usage in Twig: {{ schema.render()|raw }}
+ */
+class AddSchemaToTimberContext implements Hooks
+{
+    private SchemaManager $schemaManager;
+
+    private HookDispatcherInterface $hookDispatcher;
+
+    public function __construct(SchemaManager $schemaManager, HookDispatcherInterface $hookDispatcher)
+    {
+        $this->schemaManager = $schemaManager;
+        $this->hookDispatcher = $hookDispatcher;
+    }
+
+    public function hooks(): void
+    {
+        $this->hookDispatcher->addFilter('timber/context', [$this, 'addSchema']);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     * @return array<string, mixed>
+     */
+    public function addSchema(array $context): array
+    {
+        $context['schema'] = $this->schemaManager;
+
+        return $context;
+    }
+}

--- a/src/Seo/Hooks/InjectSchemaInHead.php
+++ b/src/Seo/Hooks/InjectSchemaInHead.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Hooks;
+
+use BackTo\Framework\Contracts\HookDispatcherInterface;
+use BackTo\Framework\Contracts\Hooks;
+use BackTo\Framework\Seo\Schema\SchemaManager;
+
+/**
+ * Inject JSON-LD structured data into the <head> via wp_head.
+ */
+class InjectSchemaInHead implements Hooks
+{
+    private SchemaManager $schemaManager;
+
+    private HookDispatcherInterface $hookDispatcher;
+
+    public function __construct(SchemaManager $schemaManager, HookDispatcherInterface $hookDispatcher)
+    {
+        $this->schemaManager = $schemaManager;
+        $this->hookDispatcher = $hookDispatcher;
+    }
+
+    public function hooks(): void
+    {
+        $this->hookDispatcher->addAction('wp_head', [$this, 'render'], 1);
+    }
+
+    public function render(): void
+    {
+        $output = $this->schemaManager->render();
+
+        if ($output !== '') {
+            echo $output . "\n";
+        }
+    }
+}

--- a/src/Seo/Hooks/RegisterDefaultSchemas.php
+++ b/src/Seo/Hooks/RegisterDefaultSchemas.php
@@ -6,15 +6,15 @@ namespace BackTo\Framework\Seo\Hooks;
 
 use BackTo\Framework\Contracts\HookDispatcherInterface;
 use BackTo\Framework\Contracts\Hooks;
-use BackTo\Framework\Seo\Schema\Generator\ArticleSchemaGenerator;
 use BackTo\Framework\Seo\Schema\Generator\BreadcrumbSchemaGenerator;
 use BackTo\Framework\Seo\Schema\Generator\OrganizationSchemaGenerator;
+use BackTo\Framework\Seo\Schema\Generator\PostTypeSchemaResolver;
 use BackTo\Framework\Seo\Schema\Generator\WebSiteSchemaGenerator;
 use BackTo\Framework\Seo\Schema\SchemaManager;
 
 /**
- * Register default schemas (WebSite, Organization, Article, Breadcrumb)
- * and apply the 'framework/seo/schema' filter for theme customization.
+ * Register default schemas (WebSite, Organization, post type schema, Breadcrumb)
+ * and fire the 'framework/seo/schema' action for theme customization.
  */
 class RegisterDefaultSchemas implements Hooks
 {
@@ -26,7 +26,7 @@ class RegisterDefaultSchemas implements Hooks
 
     private OrganizationSchemaGenerator $organizationGenerator;
 
-    private ArticleSchemaGenerator $articleGenerator;
+    private PostTypeSchemaResolver $postTypeResolver;
 
     private BreadcrumbSchemaGenerator $breadcrumbGenerator;
 
@@ -35,14 +35,14 @@ class RegisterDefaultSchemas implements Hooks
         HookDispatcherInterface $hookDispatcher,
         WebSiteSchemaGenerator $webSiteGenerator,
         OrganizationSchemaGenerator $organizationGenerator,
-        ArticleSchemaGenerator $articleGenerator,
+        PostTypeSchemaResolver $postTypeResolver,
         BreadcrumbSchemaGenerator $breadcrumbGenerator,
     ) {
         $this->schemaManager = $schemaManager;
         $this->hookDispatcher = $hookDispatcher;
         $this->webSiteGenerator = $webSiteGenerator;
         $this->organizationGenerator = $organizationGenerator;
-        $this->articleGenerator = $articleGenerator;
+        $this->postTypeResolver = $postTypeResolver;
         $this->breadcrumbGenerator = $breadcrumbGenerator;
     }
 
@@ -56,11 +56,7 @@ class RegisterDefaultSchemas implements Hooks
         $this->schemaManager->add($this->webSiteGenerator->generate());
         $this->schemaManager->add($this->organizationGenerator->generate());
 
-        $article = $this->articleGenerator->generate();
-
-        if ($article !== null) {
-            $this->schemaManager->add($article);
-        }
+        $this->registerPostTypeSchema();
 
         $breadcrumb = $this->breadcrumbGenerator->generate();
 
@@ -83,6 +79,25 @@ class RegisterDefaultSchemas implements Hooks
          */
         if (\function_exists('do_action')) {
             \do_action('framework/seo/schema', $this->schemaManager);
+        }
+    }
+
+    private function registerPostTypeSchema(): void
+    {
+        if (!\function_exists('is_singular') || !\is_singular()) {
+            return;
+        }
+
+        $post = \function_exists('get_queried_object') ? \get_queried_object() : null;
+
+        if (!$post instanceof \WP_Post) {
+            return;
+        }
+
+        $schema = $this->postTypeResolver->resolve($post->post_type, $post->ID);
+
+        if ($schema !== null) {
+            $this->schemaManager->add($schema);
         }
     }
 }

--- a/src/Seo/Hooks/RegisterDefaultSchemas.php
+++ b/src/Seo/Hooks/RegisterDefaultSchemas.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Hooks;
+
+use BackTo\Framework\Contracts\HookDispatcherInterface;
+use BackTo\Framework\Contracts\Hooks;
+use BackTo\Framework\Seo\Schema\Generator\ArticleSchemaGenerator;
+use BackTo\Framework\Seo\Schema\Generator\BreadcrumbSchemaGenerator;
+use BackTo\Framework\Seo\Schema\Generator\OrganizationSchemaGenerator;
+use BackTo\Framework\Seo\Schema\Generator\WebSiteSchemaGenerator;
+use BackTo\Framework\Seo\Schema\SchemaManager;
+
+/**
+ * Register default schemas (WebSite, Organization, Article, Breadcrumb)
+ * and apply the 'framework/seo/schema' filter for theme customization.
+ */
+class RegisterDefaultSchemas implements Hooks
+{
+    private SchemaManager $schemaManager;
+
+    private HookDispatcherInterface $hookDispatcher;
+
+    private WebSiteSchemaGenerator $webSiteGenerator;
+
+    private OrganizationSchemaGenerator $organizationGenerator;
+
+    private ArticleSchemaGenerator $articleGenerator;
+
+    private BreadcrumbSchemaGenerator $breadcrumbGenerator;
+
+    public function __construct(
+        SchemaManager $schemaManager,
+        HookDispatcherInterface $hookDispatcher,
+        WebSiteSchemaGenerator $webSiteGenerator,
+        OrganizationSchemaGenerator $organizationGenerator,
+        ArticleSchemaGenerator $articleGenerator,
+        BreadcrumbSchemaGenerator $breadcrumbGenerator,
+    ) {
+        $this->schemaManager = $schemaManager;
+        $this->hookDispatcher = $hookDispatcher;
+        $this->webSiteGenerator = $webSiteGenerator;
+        $this->organizationGenerator = $organizationGenerator;
+        $this->articleGenerator = $articleGenerator;
+        $this->breadcrumbGenerator = $breadcrumbGenerator;
+    }
+
+    public function hooks(): void
+    {
+        $this->hookDispatcher->addAction('wp', [$this, 'register']);
+    }
+
+    public function register(): void
+    {
+        $this->schemaManager->add($this->webSiteGenerator->generate());
+        $this->schemaManager->add($this->organizationGenerator->generate());
+
+        $article = $this->articleGenerator->generate();
+
+        if ($article !== null) {
+            $this->schemaManager->add($article);
+        }
+
+        $breadcrumb = $this->breadcrumbGenerator->generate();
+
+        if ($breadcrumb !== null) {
+            $this->schemaManager->add($breadcrumb);
+        }
+
+        /**
+         * Action fired after default schemas are registered.
+         *
+         * Allows themes and plugins to add, remove, or modify schemas
+         * before they are rendered in the <head>.
+         *
+         * Usage in theme:
+         *   add_action('framework/seo/schema', function (SchemaManager $manager) {
+         *       $manager->add(Schema::faqPage()->mainEntity([...]));
+         *   });
+         *
+         * @param SchemaManager $schemaManager The schema manager instance.
+         */
+        if (\function_exists('do_action')) {
+            \do_action('framework/seo/schema', $this->schemaManager);
+        }
+    }
+}

--- a/src/Seo/Schema.php
+++ b/src/Seo/Schema.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BackTo\Framework\Seo;
 
+use BackTo\Framework\Seo\Schema\SchemaRef;
 use BackTo\Framework\Seo\Schema\SchemaType;
 use BackTo\Framework\Seo\Schema\Type\AggregateRating;
 use BackTo\Framework\Seo\Schema\Type\Answer;
@@ -207,5 +208,15 @@ final class Schema
     public static function type(string $type): SchemaType
     {
         return new SchemaType($type);
+    }
+
+    /**
+     * Create a reference to another schema node by @id.
+     *
+     * Usage: Schema::ref('#organization') produces {"@id": "#organization"}
+     */
+    public static function ref(string $id): SchemaRef
+    {
+        return new SchemaRef($id);
     }
 }

--- a/src/Seo/Schema.php
+++ b/src/Seo/Schema.php
@@ -5,15 +5,23 @@ declare(strict_types=1);
 namespace BackTo\Framework\Seo;
 
 use BackTo\Framework\Seo\Schema\SchemaType;
+use BackTo\Framework\Seo\Schema\Type\AggregateRating;
 use BackTo\Framework\Seo\Schema\Type\Article;
 use BackTo\Framework\Seo\Schema\Type\BreadcrumbList;
+use BackTo\Framework\Seo\Schema\Type\Course;
+use BackTo\Framework\Seo\Schema\Type\CourseInstance;
+use BackTo\Framework\Seo\Schema\Type\Event;
+use BackTo\Framework\Seo\Schema\Type\GeoCoordinates;
 use BackTo\Framework\Seo\Schema\Type\ImageObject;
 use BackTo\Framework\Seo\Schema\Type\ListItem;
 use BackTo\Framework\Seo\Schema\Type\LocalBusiness;
+use BackTo\Framework\Seo\Schema\Type\Offer;
 use BackTo\Framework\Seo\Schema\Type\Organization;
 use BackTo\Framework\Seo\Schema\Type\Person;
+use BackTo\Framework\Seo\Schema\Type\Place;
 use BackTo\Framework\Seo\Schema\Type\PostalAddress;
 use BackTo\Framework\Seo\Schema\Type\SearchAction;
+use BackTo\Framework\Seo\Schema\Type\VirtualLocation;
 use BackTo\Framework\Seo\Schema\Type\WebSite;
 
 /**
@@ -73,6 +81,46 @@ final class Schema
     public static function searchAction(): SearchAction
     {
         return new SearchAction();
+    }
+
+    public static function event(): Event
+    {
+        return new Event();
+    }
+
+    public static function course(): Course
+    {
+        return new Course();
+    }
+
+    public static function courseInstance(): CourseInstance
+    {
+        return new CourseInstance();
+    }
+
+    public static function offer(): Offer
+    {
+        return new Offer();
+    }
+
+    public static function place(): Place
+    {
+        return new Place();
+    }
+
+    public static function virtualLocation(): VirtualLocation
+    {
+        return new VirtualLocation();
+    }
+
+    public static function geoCoordinates(): GeoCoordinates
+    {
+        return new GeoCoordinates();
+    }
+
+    public static function aggregateRating(): AggregateRating
+    {
+        return new AggregateRating();
     }
 
     /**

--- a/src/Seo/Schema.php
+++ b/src/Seo/Schema.php
@@ -6,21 +6,34 @@ namespace BackTo\Framework\Seo;
 
 use BackTo\Framework\Seo\Schema\SchemaType;
 use BackTo\Framework\Seo\Schema\Type\AggregateRating;
+use BackTo\Framework\Seo\Schema\Type\Answer;
 use BackTo\Framework\Seo\Schema\Type\Article;
+use BackTo\Framework\Seo\Schema\Type\Brand;
 use BackTo\Framework\Seo\Schema\Type\BreadcrumbList;
+use BackTo\Framework\Seo\Schema\Type\Clip;
 use BackTo\Framework\Seo\Schema\Type\Course;
 use BackTo\Framework\Seo\Schema\Type\CourseInstance;
 use BackTo\Framework\Seo\Schema\Type\Event;
+use BackTo\Framework\Seo\Schema\Type\FAQPage;
 use BackTo\Framework\Seo\Schema\Type\GeoCoordinates;
 use BackTo\Framework\Seo\Schema\Type\ImageObject;
+use BackTo\Framework\Seo\Schema\Type\JobPosting;
 use BackTo\Framework\Seo\Schema\Type\ListItem;
 use BackTo\Framework\Seo\Schema\Type\LocalBusiness;
+use BackTo\Framework\Seo\Schema\Type\MerchantReturnPolicy;
+use BackTo\Framework\Seo\Schema\Type\MonetaryAmount;
 use BackTo\Framework\Seo\Schema\Type\Offer;
+use BackTo\Framework\Seo\Schema\Type\OfferShippingDetails;
 use BackTo\Framework\Seo\Schema\Type\Organization;
 use BackTo\Framework\Seo\Schema\Type\Person;
 use BackTo\Framework\Seo\Schema\Type\Place;
 use BackTo\Framework\Seo\Schema\Type\PostalAddress;
+use BackTo\Framework\Seo\Schema\Type\Product;
+use BackTo\Framework\Seo\Schema\Type\Question;
+use BackTo\Framework\Seo\Schema\Type\Rating;
+use BackTo\Framework\Seo\Schema\Type\Review;
 use BackTo\Framework\Seo\Schema\Type\SearchAction;
+use BackTo\Framework\Seo\Schema\Type\VideoObject;
 use BackTo\Framework\Seo\Schema\Type\VirtualLocation;
 use BackTo\Framework\Seo\Schema\Type\WebSite;
 
@@ -121,6 +134,71 @@ final class Schema
     public static function aggregateRating(): AggregateRating
     {
         return new AggregateRating();
+    }
+
+    public static function product(): Product
+    {
+        return new Product();
+    }
+
+    public static function brand(): Brand
+    {
+        return new Brand();
+    }
+
+    public static function offerShippingDetails(): OfferShippingDetails
+    {
+        return new OfferShippingDetails();
+    }
+
+    public static function merchantReturnPolicy(): MerchantReturnPolicy
+    {
+        return new MerchantReturnPolicy();
+    }
+
+    public static function monetaryAmount(): MonetaryAmount
+    {
+        return new MonetaryAmount();
+    }
+
+    public static function review(): Review
+    {
+        return new Review();
+    }
+
+    public static function rating(): Rating
+    {
+        return new Rating();
+    }
+
+    public static function videoObject(): VideoObject
+    {
+        return new VideoObject();
+    }
+
+    public static function clip(): Clip
+    {
+        return new Clip();
+    }
+
+    public static function faqPage(): FAQPage
+    {
+        return new FAQPage();
+    }
+
+    public static function question(): Question
+    {
+        return new Question();
+    }
+
+    public static function answer(): Answer
+    {
+        return new Answer();
+    }
+
+    public static function jobPosting(): JobPosting
+    {
+        return new JobPosting();
     }
 
     /**

--- a/src/Seo/Schema.php
+++ b/src/Seo/Schema.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+use BackTo\Framework\Seo\Schema\Type\Article;
+use BackTo\Framework\Seo\Schema\Type\BreadcrumbList;
+use BackTo\Framework\Seo\Schema\Type\ImageObject;
+use BackTo\Framework\Seo\Schema\Type\ListItem;
+use BackTo\Framework\Seo\Schema\Type\LocalBusiness;
+use BackTo\Framework\Seo\Schema\Type\Organization;
+use BackTo\Framework\Seo\Schema\Type\Person;
+use BackTo\Framework\Seo\Schema\Type\PostalAddress;
+use BackTo\Framework\Seo\Schema\Type\SearchAction;
+use BackTo\Framework\Seo\Schema\Type\WebSite;
+
+/**
+ * Static factory for creating schema.org types.
+ *
+ * Usage:
+ *   Schema::organization()->name('Acme')->url('https://acme.com');
+ *   Schema::article()->headline('Title')->author(Schema::person()->name('John'));
+ */
+final class Schema
+{
+    public static function organization(): Organization
+    {
+        return new Organization();
+    }
+
+    public static function localBusiness(): LocalBusiness
+    {
+        return new LocalBusiness();
+    }
+
+    public static function article(): Article
+    {
+        return new Article();
+    }
+
+    public static function breadcrumbList(): BreadcrumbList
+    {
+        return new BreadcrumbList();
+    }
+
+    public static function listItem(): ListItem
+    {
+        return new ListItem();
+    }
+
+    public static function person(): Person
+    {
+        return new Person();
+    }
+
+    public static function postalAddress(): PostalAddress
+    {
+        return new PostalAddress();
+    }
+
+    public static function webSite(): WebSite
+    {
+        return new WebSite();
+    }
+
+    public static function imageObject(): ImageObject
+    {
+        return new ImageObject();
+    }
+
+    public static function searchAction(): SearchAction
+    {
+        return new SearchAction();
+    }
+
+    /**
+     * Create a generic schema type by name.
+     */
+    public static function type(string $type): SchemaType
+    {
+        return new SchemaType($type);
+    }
+}

--- a/src/Seo/Schema/Generator/ArticleSchemaGenerator.php
+++ b/src/Seo/Schema/Generator/ArticleSchemaGenerator.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Generator;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+/**
+ * Generates an Article schema from a WordPress post.
+ */
+class ArticleSchemaGenerator
+{
+    public function generate(?int $postId = null): ?SchemaType
+    {
+        $post = \get_post($postId);
+
+        if (!$post instanceof \WP_Post) {
+            return null;
+        }
+
+        if ($post->post_type !== 'post') {
+            return null;
+        }
+
+        $article = Schema::article()
+            ->headline($post->post_title)
+            ->url(\get_permalink($post))
+            ->datePublished(\get_the_date('c', $post))
+            ->dateModified(\get_the_modified_date('c', $post));
+
+        $author = \get_userdata($post->post_author);
+
+        if ($author !== false) {
+            $article->author(Schema::person()->name($author->display_name));
+        }
+
+        $thumbnailUrl = \get_the_post_thumbnail_url($post, 'full');
+
+        if (\is_string($thumbnailUrl) && $thumbnailUrl !== '') {
+            $article->image($thumbnailUrl);
+        }
+
+        $description = \get_the_excerpt($post);
+
+        if (\is_string($description) && $description !== '') {
+            $article->description($description);
+        }
+
+        return $article;
+    }
+}

--- a/src/Seo/Schema/Generator/ArticleSchemaGenerator.php
+++ b/src/Seo/Schema/Generator/ArticleSchemaGenerator.php
@@ -9,6 +9,8 @@ use BackTo\Framework\Seo\Schema\SchemaType;
 
 /**
  * Generates an Article schema from a WordPress post.
+ *
+ * Links to "#organization" as publisher and "#website" as isPartOf.
  */
 class ArticleSchemaGenerator
 {
@@ -24,11 +26,17 @@ class ArticleSchemaGenerator
             return null;
         }
 
+        $siteUrl = \home_url('/');
+        $permalink = \get_permalink($post);
+
         $article = Schema::article()
+            ->id($permalink . '#article')
             ->headline($post->post_title)
-            ->url(\get_permalink($post))
+            ->url($permalink)
             ->datePublished(\get_the_date('c', $post))
-            ->dateModified(\get_the_modified_date('c', $post));
+            ->dateModified(\get_the_modified_date('c', $post))
+            ->set('isPartOf', Schema::ref($siteUrl . '#website'))
+            ->publisher(Schema::ref($siteUrl . '#organization'));
 
         $author = \get_userdata($post->post_author);
 

--- a/src/Seo/Schema/Generator/BreadcrumbSchemaGenerator.php
+++ b/src/Seo/Schema/Generator/BreadcrumbSchemaGenerator.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Generator;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+/**
+ * Generates a BreadcrumbList schema from the current WordPress page context.
+ */
+class BreadcrumbSchemaGenerator
+{
+    public function generate(): ?SchemaType
+    {
+        $items = $this->buildItems();
+
+        if (\count($items) < 2) {
+            return null;
+        }
+
+        $listItems = [];
+
+        foreach ($items as $position => $item) {
+            $listItem = Schema::listItem()
+                ->position($position + 1)
+                ->name($item['name']);
+
+            if (isset($item['url'])) {
+                $listItem->url($item['url']);
+            }
+
+            $listItems[] = $listItem;
+        }
+
+        return Schema::breadcrumbList()->items($listItems);
+    }
+
+    /**
+     * @return array<int, array{name: string, url?: string}>
+     */
+    private function buildItems(): array
+    {
+        $items = [];
+        $items[] = ['name' => \get_bloginfo('name'), 'url' => \home_url('/')];
+
+        if (\is_singular()) {
+            $post = \get_queried_object();
+
+            if (!$post instanceof \WP_Post) {
+                return $items;
+            }
+
+            if ($post->post_type === 'post') {
+                $this->addPostArchive($items);
+                $this->addPostCategories($items, $post);
+            } elseif ($post->post_type === 'page') {
+                $this->addPageAncestors($items, $post);
+            } else {
+                $this->addCustomPostTypeArchive($items, $post);
+            }
+
+            $items[] = ['name' => $post->post_title];
+        } elseif (\is_category() || \is_tag() || \is_tax()) {
+            $term = \get_queried_object();
+
+            if ($term instanceof \WP_Term) {
+                $this->addTermAncestors($items, $term);
+                $items[] = ['name' => $term->name];
+            }
+        } elseif (\is_post_type_archive()) {
+            $postType = \get_queried_object();
+
+            if ($postType instanceof \WP_Post_Type) {
+                $items[] = ['name' => $postType->labels->name];
+            }
+        } elseif (\is_author()) {
+            $author = \get_queried_object();
+
+            if ($author instanceof \WP_User) {
+                $items[] = ['name' => $author->display_name];
+            }
+        } elseif (\is_search()) {
+            $items[] = ['name' => \get_search_query()];
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param array<int, array{name: string, url?: string}> $items
+     */
+    private function addPostArchive(array &$items): void
+    {
+        $pageForPosts = (int) \get_option('page_for_posts');
+
+        if ($pageForPosts > 0) {
+            $blogPage = \get_post($pageForPosts);
+
+            if ($blogPage instanceof \WP_Post) {
+                $items[] = ['name' => $blogPage->post_title, 'url' => \get_permalink($blogPage)];
+            }
+        }
+    }
+
+    /**
+     * @param array<int, array{name: string, url?: string}> $items
+     */
+    private function addPostCategories(array &$items, \WP_Post $post): void
+    {
+        $categories = \get_the_category($post->ID);
+
+        if (!empty($categories)) {
+            $category = $categories[0];
+            $link = \get_category_link($category->term_id);
+
+            if (\is_string($link)) {
+                $items[] = ['name' => $category->name, 'url' => $link];
+            }
+        }
+    }
+
+    /**
+     * @param array<int, array{name: string, url?: string}> $items
+     */
+    private function addPageAncestors(array &$items, \WP_Post $page): void
+    {
+        $ancestors = \get_post_ancestors($page);
+
+        foreach (array_reverse($ancestors) as $ancestorId) {
+            $ancestor = \get_post($ancestorId);
+
+            if ($ancestor instanceof \WP_Post) {
+                $items[] = ['name' => $ancestor->post_title, 'url' => \get_permalink($ancestor)];
+            }
+        }
+    }
+
+    /**
+     * @param array<int, array{name: string, url?: string}> $items
+     */
+    private function addCustomPostTypeArchive(array &$items, \WP_Post $post): void
+    {
+        $postTypeObj = \get_post_type_object($post->post_type);
+
+        if ($postTypeObj !== null && $postTypeObj->has_archive) {
+            $archiveUrl = \get_post_type_archive_link($post->post_type);
+
+            if (\is_string($archiveUrl)) {
+                $items[] = ['name' => $postTypeObj->labels->name, 'url' => $archiveUrl];
+            }
+        }
+    }
+
+    /**
+     * @param array<int, array{name: string, url?: string}> $items
+     */
+    private function addTermAncestors(array &$items, \WP_Term $term): void
+    {
+        if (!$term->parent) {
+            return;
+        }
+
+        $ancestors = \get_ancestors($term->term_id, $term->taxonomy, 'taxonomy');
+
+        foreach (array_reverse($ancestors) as $ancestorId) {
+            $ancestor = \get_term($ancestorId, $term->taxonomy);
+
+            if ($ancestor instanceof \WP_Term) {
+                $link = \get_term_link($ancestor);
+
+                if (\is_string($link)) {
+                    $items[] = ['name' => $ancestor->name, 'url' => $link];
+                }
+            }
+        }
+    }
+}

--- a/src/Seo/Schema/Generator/OrganizationSchemaGenerator.php
+++ b/src/Seo/Schema/Generator/OrganizationSchemaGenerator.php
@@ -10,6 +10,8 @@ use BackTo\Framework\Seo\SeoManager;
 
 /**
  * Generates an Organization schema from WordPress settings and SEO provider social links.
+ *
+ * Produces an Organization node with @id "#organization".
  */
 class OrganizationSchemaGenerator
 {
@@ -22,9 +24,12 @@ class OrganizationSchemaGenerator
 
     public function generate(): SchemaType
     {
+        $siteUrl = \home_url('/');
+
         $org = Schema::organization()
+            ->id($siteUrl . '#organization')
             ->name(\get_bloginfo('name'))
-            ->url(\home_url('/'));
+            ->url($siteUrl);
 
         $customLogoId = \get_theme_mod('custom_logo');
 

--- a/src/Seo/Schema/Generator/OrganizationSchemaGenerator.php
+++ b/src/Seo/Schema/Generator/OrganizationSchemaGenerator.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Generator;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaType;
+use BackTo\Framework\Seo\SeoManager;
+
+/**
+ * Generates an Organization schema from WordPress settings and SEO provider social links.
+ */
+class OrganizationSchemaGenerator
+{
+    private SeoManager $seoManager;
+
+    public function __construct(SeoManager $seoManager)
+    {
+        $this->seoManager = $seoManager;
+    }
+
+    public function generate(): SchemaType
+    {
+        $org = Schema::organization()
+            ->name(\get_bloginfo('name'))
+            ->url(\home_url('/'));
+
+        $customLogoId = \get_theme_mod('custom_logo');
+
+        if ($customLogoId) {
+            $logoUrl = \wp_get_attachment_image_url($customLogoId, 'full');
+
+            if (\is_string($logoUrl) && $logoUrl !== '') {
+                $org->logo($logoUrl);
+            }
+        }
+
+        $sameAs = $this->buildSameAs();
+
+        if ($sameAs !== []) {
+            $org->sameAs($sameAs);
+        }
+
+        return $org;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function buildSameAs(): array
+    {
+        if (!$this->seoManager->hasProvider()) {
+            return [];
+        }
+
+        $links = $this->seoManager->getSocialLinks();
+
+        return array_values(array_filter($links, fn (?string $url): bool => \is_string($url) && $url !== ''));
+    }
+}

--- a/src/Seo/Schema/Generator/PostTypeSchemaResolver.php
+++ b/src/Seo/Schema/Generator/PostTypeSchemaResolver.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Generator;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+/**
+ * Resolves a schema for a given post based on a post_type → generator mapping.
+ *
+ * The mapping is loaded from the `seo.php` configuration file:
+ *
+ *   return [
+ *       'schema' => [
+ *           'post_type_map' => [
+ *               'post'       => \BackTo\Framework\Seo\Schema\Generator\ArticleSchemaGenerator::class,
+ *               'formation'  => \App\Seo\CourseSchemaGenerator::class,
+ *               'evenement'  => \App\Seo\EventSchemaGenerator::class,
+ *           ],
+ *       ],
+ *   ];
+ *
+ * Each generator must implement a `generate(?int $postId): ?SchemaType` method.
+ */
+class PostTypeSchemaResolver
+{
+    /** @var array<string, object> */
+    private array $generators;
+
+    /**
+     * @param array<string, object> $generators Mapping of post_type => generator instance
+     */
+    public function __construct(array $generators = [])
+    {
+        $this->generators = $generators;
+    }
+
+    /**
+     * Add a generator for a post type.
+     *
+     * @return $this
+     */
+    public function addGenerator(string $postType, object $generator): self
+    {
+        $this->generators[$postType] = $generator;
+
+        return $this;
+    }
+
+    /**
+     * Whether a generator is registered for the given post type.
+     */
+    public function supports(string $postType): bool
+    {
+        return isset($this->generators[$postType]);
+    }
+
+    /**
+     * Resolve a schema for the given post.
+     */
+    public function resolve(string $postType, ?int $postId = null): ?SchemaType
+    {
+        if (!$this->supports($postType)) {
+            return null;
+        }
+
+        $generator = $this->generators[$postType];
+
+        return $generator->generate($postId);
+    }
+
+    /**
+     * @return array<string, object>
+     */
+    public function getGenerators(): array
+    {
+        return $this->generators;
+    }
+}

--- a/src/Seo/Schema/Generator/WebSiteSchemaGenerator.php
+++ b/src/Seo/Schema/Generator/WebSiteSchemaGenerator.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Generator;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+/**
+ * Generates a WebSite schema from WordPress site settings.
+ *
+ * Produces a WebSite node with a SearchAction (sitelinks search box).
+ */
+class WebSiteSchemaGenerator
+{
+    public function generate(): SchemaType
+    {
+        $siteUrl = \home_url('/');
+
+        return Schema::webSite()
+            ->name(\get_bloginfo('name'))
+            ->url($siteUrl)
+            ->description(\get_bloginfo('description'))
+            ->potentialAction(
+                Schema::searchAction()
+                    ->target($siteUrl . '?s={search_term_string}')
+                    ->queryInput('required name=search_term_string')
+            );
+    }
+}

--- a/src/Seo/Schema/Generator/WebSiteSchemaGenerator.php
+++ b/src/Seo/Schema/Generator/WebSiteSchemaGenerator.php
@@ -10,7 +10,8 @@ use BackTo\Framework\Seo\Schema\SchemaType;
 /**
  * Generates a WebSite schema from WordPress site settings.
  *
- * Produces a WebSite node with a SearchAction (sitelinks search box).
+ * Produces a WebSite node with @id "#website", linked to "#organization" as publisher,
+ * and a SearchAction for the sitelinks search box.
  */
 class WebSiteSchemaGenerator
 {
@@ -19,9 +20,11 @@ class WebSiteSchemaGenerator
         $siteUrl = \home_url('/');
 
         return Schema::webSite()
+            ->id($siteUrl . '#website')
             ->name(\get_bloginfo('name'))
             ->url($siteUrl)
             ->description(\get_bloginfo('description'))
+            ->publisher(Schema::ref($siteUrl . '#organization'))
             ->potentialAction(
                 Schema::searchAction()
                     ->target($siteUrl . '?s={search_term_string}')

--- a/src/Seo/Schema/SchemaManager.php
+++ b/src/Seo/Schema/SchemaManager.php
@@ -45,6 +45,29 @@ class SchemaManager
     }
 
     /**
+     * Validate all registered schemas.
+     *
+     * Returns an array keyed by schema type with missing required properties.
+     * An empty array means all schemas are valid.
+     *
+     * @return array<string, string[]>
+     */
+    public function validate(): array
+    {
+        $errors = [];
+
+        foreach ($this->schemas as $schema) {
+            $missing = $schema->validate();
+
+            if ($missing !== []) {
+                $errors[$schema->getType()] = $missing;
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
      * Export all schemas as an array of JSON-LD data.
      *
      * @return array<int, array<string, mixed>>

--- a/src/Seo/Schema/SchemaManager.php
+++ b/src/Seo/Schema/SchemaManager.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema;
+
+/**
+ * Central registry for schema.org structured data.
+ *
+ * Collects SchemaType instances and renders them as a JSON-LD script block.
+ */
+class SchemaManager
+{
+    /** @var SchemaType[] */
+    private array $schemas = [];
+
+    /**
+     * Add a schema to the registry.
+     *
+     * @return $this
+     */
+    public function add(SchemaType $schema): self
+    {
+        $this->schemas[] = $schema;
+
+        return $this;
+    }
+
+    /**
+     * Whether any schemas have been registered.
+     */
+    public function hasSchemas(): bool
+    {
+        return $this->schemas !== [];
+    }
+
+    /**
+     * Get all registered schemas.
+     *
+     * @return SchemaType[]
+     */
+    public function getSchemas(): array
+    {
+        return $this->schemas;
+    }
+
+    /**
+     * Export all schemas as an array of JSON-LD data.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        return array_map(
+            fn (SchemaType $schema): array => $schema->toArray(),
+            $this->schemas,
+        );
+    }
+
+    /**
+     * Render all schemas as a JSON-LD <script> block for injection in <head>.
+     *
+     * Uses a @graph when multiple schemas are registered,
+     * or a single object when only one is present.
+     */
+    public function render(): string
+    {
+        if (!$this->hasSchemas()) {
+            return '';
+        }
+
+        $schemas = $this->toArray();
+
+        if (\count($schemas) === 1) {
+            $data = ['@context' => 'https://schema.org'] + $schemas[0];
+        } else {
+            $data = [
+                '@context' => 'https://schema.org',
+                '@graph' => $schemas,
+            ];
+        }
+
+        $json = json_encode($data, \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT);
+
+        return '<script type="application/ld+json">' . "\n" . $json . "\n" . '</script>';
+    }
+}

--- a/src/Seo/Schema/SchemaRef.php
+++ b/src/Seo/Schema/SchemaRef.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema;
+
+/**
+ * Represents a JSON-LD @id reference to another node in the graph.
+ *
+ * Used to link schemas without duplicating data:
+ *   "publisher": { "@id": "#organization" }
+ */
+class SchemaRef implements \JsonSerializable
+{
+    private string $id;
+
+    public function __construct(string $id)
+    {
+        $this->id = $id;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return array{@id: string}
+     */
+    public function toArray(): array
+    {
+        return ['@id' => $this->id];
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Seo/Schema/SchemaType.php
+++ b/src/Seo/Schema/SchemaType.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema;
+
+/**
+ * Base class for all schema.org types.
+ *
+ * Provides a fluent builder API for constructing JSON-LD structured data.
+ */
+class SchemaType implements \JsonSerializable
+{
+    protected string $type;
+
+    /** @var array<string, mixed> */
+    protected array $properties = [];
+
+    public function __construct(string $type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * Set an arbitrary property on the schema.
+     *
+     * @return $this
+     */
+    public function set(string $property, mixed $value): static
+    {
+        $this->properties[$property] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Set the @id for this schema node.
+     *
+     * @return $this
+     */
+    public function id(string $id): static
+    {
+        return $this->set('@id', $id);
+    }
+
+    /**
+     * Get the schema.org @type.
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    /**
+     * Get all properties.
+     *
+     * @return array<string, mixed>
+     */
+    public function getProperties(): array
+    {
+        return $this->properties;
+    }
+
+    /**
+     * Convert the schema to an associative array suitable for JSON-LD output.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $data = ['@type' => $this->type];
+
+        foreach ($this->properties as $key => $value) {
+            $data[$key] = $this->resolveValue($value);
+        }
+
+        return $data;
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Resolve a value for JSON-LD output, handling nested SchemaType objects and arrays.
+     */
+    private function resolveValue(mixed $value): mixed
+    {
+        if ($value instanceof self) {
+            return $value->toArray();
+        }
+
+        if (\is_array($value)) {
+            return array_map(fn (mixed $item): mixed => $this->resolveValue($item), $value);
+        }
+
+        return $value;
+    }
+}

--- a/src/Seo/Schema/SchemaType.php
+++ b/src/Seo/Schema/SchemaType.php
@@ -77,6 +77,53 @@ class SchemaType implements \JsonSerializable
         return $data;
     }
 
+    /**
+     * Validate the schema against Google's required properties.
+     *
+     * Returns an array of missing required property names.
+     * An empty array means the schema is valid for rich results.
+     *
+     * @return string[]
+     */
+    public function validate(): array
+    {
+        $required = $this->getRequiredProperties();
+
+        if ($required === []) {
+            return [];
+        }
+
+        $missing = [];
+
+        foreach ($required as $property) {
+            if (!isset($this->properties[$property])) {
+                $missing[] = $property;
+            }
+        }
+
+        return $missing;
+    }
+
+    /**
+     * Whether this schema has all required properties for Google rich results.
+     */
+    public function isValid(): bool
+    {
+        return $this->validate() === [];
+    }
+
+    /**
+     * Return the list of properties required by Google for this schema type.
+     *
+     * Override in concrete types to define required properties.
+     *
+     * @return string[]
+     */
+    protected function getRequiredProperties(): array
+    {
+        return [];
+    }
+
     public function jsonSerialize(): mixed
     {
         return $this->toArray();
@@ -87,6 +134,10 @@ class SchemaType implements \JsonSerializable
      */
     private function resolveValue(mixed $value): mixed
     {
+        if ($value instanceof SchemaRef) {
+            return $value->toArray();
+        }
+
         if ($value instanceof self) {
             return $value->toArray();
         }

--- a/src/Seo/Schema/Type/AggregateRating.php
+++ b/src/Seo/Schema/Type/AggregateRating.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class AggregateRating extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('AggregateRating');
+    }
+
+    /** @return $this */
+    public function ratingValue(float|string $value): static
+    {
+        return $this->set('ratingValue', $value);
+    }
+
+    /** @return $this */
+    public function bestRating(float|string $value): static
+    {
+        return $this->set('bestRating', $value);
+    }
+
+    /** @return $this */
+    public function worstRating(float|string $value): static
+    {
+        return $this->set('worstRating', $value);
+    }
+
+    /** @return $this */
+    public function ratingCount(int $count): static
+    {
+        return $this->set('ratingCount', $count);
+    }
+
+    /** @return $this */
+    public function reviewCount(int $count): static
+    {
+        return $this->set('reviewCount', $count);
+    }
+}

--- a/src/Seo/Schema/Type/Answer.php
+++ b/src/Seo/Schema/Type/Answer.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Answer extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Answer');
+    }
+
+    /** @return $this */
+    public function text(string $text): static
+    {
+        return $this->set('text', $text);
+    }
+}

--- a/src/Seo/Schema/Type/Article.php
+++ b/src/Seo/Schema/Type/Article.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Article extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Article');
+    }
+
+    /** @return $this */
+    public function headline(string $headline): static
+    {
+        return $this->set('headline', $headline);
+    }
+
+    /** @return $this */
+    public function description(string $description): static
+    {
+        return $this->set('description', $description);
+    }
+
+    /** @return $this */
+    public function author(SchemaType|string $author): static
+    {
+        return $this->set('author', $author);
+    }
+
+    /** @return $this */
+    public function publisher(SchemaType $publisher): static
+    {
+        return $this->set('publisher', $publisher);
+    }
+
+    /** @return $this */
+    public function datePublished(string $date): static
+    {
+        return $this->set('datePublished', $date);
+    }
+
+    /** @return $this */
+    public function dateModified(string $date): static
+    {
+        return $this->set('dateModified', $date);
+    }
+
+    /** @return $this */
+    public function image(string|SchemaType $image): static
+    {
+        return $this->set('image', $image);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+
+    /** @return $this */
+    public function mainEntityOfPage(string|SchemaType $page): static
+    {
+        return $this->set('mainEntityOfPage', $page);
+    }
+
+    /** @return $this */
+    public function articleSection(string $section): static
+    {
+        return $this->set('articleSection', $section);
+    }
+
+    /**
+     * @param string[] $keywords
+     * @return $this
+     */
+    public function keywords(array $keywords): static
+    {
+        return $this->set('keywords', $keywords);
+    }
+
+    /** @return $this */
+    public function wordCount(int $count): static
+    {
+        return $this->set('wordCount', $count);
+    }
+}

--- a/src/Seo/Schema/Type/Article.php
+++ b/src/Seo/Schema/Type/Article.php
@@ -13,6 +13,11 @@ class Article extends SchemaType
         parent::__construct('Article');
     }
 
+    protected function getRequiredProperties(): array
+    {
+        return ['headline', 'author', 'datePublished'];
+    }
+
     /** @return $this */
     public function headline(string $headline): static
     {

--- a/src/Seo/Schema/Type/Brand.php
+++ b/src/Seo/Schema/Type/Brand.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Brand extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Brand');
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+
+    /** @return $this */
+    public function logo(string|SchemaType $logo): static
+    {
+        return $this->set('logo', $logo);
+    }
+}

--- a/src/Seo/Schema/Type/BreadcrumbList.php
+++ b/src/Seo/Schema/Type/BreadcrumbList.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class BreadcrumbList extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('BreadcrumbList');
+    }
+
+    /**
+     * @param SchemaType[] $items ListItem instances
+     * @return $this
+     */
+    public function items(array $items): static
+    {
+        return $this->set('itemListElement', $items);
+    }
+}

--- a/src/Seo/Schema/Type/Clip.php
+++ b/src/Seo/Schema/Type/Clip.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Clip extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Clip');
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function startOffset(int $seconds): static
+    {
+        return $this->set('startOffset', $seconds);
+    }
+
+    /** @return $this */
+    public function endOffset(int $seconds): static
+    {
+        return $this->set('endOffset', $seconds);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+}

--- a/src/Seo/Schema/Type/Course.php
+++ b/src/Seo/Schema/Type/Course.php
@@ -13,6 +13,11 @@ class Course extends SchemaType
         parent::__construct('Course');
     }
 
+    protected function getRequiredProperties(): array
+    {
+        return ['name', 'description', 'provider'];
+    }
+
     /** @return $this */
     public function name(string $name): static
     {

--- a/src/Seo/Schema/Type/Course.php
+++ b/src/Seo/Schema/Type/Course.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Course extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Course');
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function description(string $description): static
+    {
+        return $this->set('description', $description);
+    }
+
+    /** @return $this */
+    public function provider(SchemaType $provider): static
+    {
+        return $this->set('provider', $provider);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+
+    /** @return $this */
+    public function image(string|SchemaType $image): static
+    {
+        return $this->set('image', $image);
+    }
+
+    /** @return $this */
+    public function inLanguage(string $language): static
+    {
+        return $this->set('inLanguage', $language);
+    }
+
+    /**
+     * @param SchemaType|SchemaType[] $instances CourseInstance objects
+     * @return $this
+     */
+    public function hasCourseInstance(SchemaType|array $instances): static
+    {
+        return $this->set('hasCourseInstance', $instances);
+    }
+
+    /**
+     * @param SchemaType|SchemaType[] $offers
+     * @return $this
+     */
+    public function offers(SchemaType|array $offers): static
+    {
+        return $this->set('offers', $offers);
+    }
+
+    /** @return $this */
+    public function courseCode(string $code): static
+    {
+        return $this->set('courseCode', $code);
+    }
+
+    /** @return $this */
+    public function educationalLevel(string $level): static
+    {
+        return $this->set('educationalLevel', $level);
+    }
+
+    /**
+     * @param string[] $prerequisites
+     * @return $this
+     */
+    public function coursePrerequisites(array $prerequisites): static
+    {
+        return $this->set('coursePrerequisites', $prerequisites);
+    }
+
+    /** @return $this */
+    public function numberOfCredits(int $credits): static
+    {
+        return $this->set('numberOfCredits', $credits);
+    }
+
+    /** @return $this */
+    public function timeRequired(string $duration): static
+    {
+        return $this->set('timeRequired', $duration);
+    }
+
+    /** @return $this */
+    public function aggregateRating(SchemaType $rating): static
+    {
+        return $this->set('aggregateRating', $rating);
+    }
+}

--- a/src/Seo/Schema/Type/CourseInstance.php
+++ b/src/Seo/Schema/Type/CourseInstance.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class CourseInstance extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('CourseInstance');
+    }
+
+    /** @return $this */
+    public function courseMode(string $mode): static
+    {
+        return $this->set('courseMode', $mode);
+    }
+
+    /** @return $this */
+    public function startDate(string $date): static
+    {
+        return $this->set('startDate', $date);
+    }
+
+    /** @return $this */
+    public function endDate(string $date): static
+    {
+        return $this->set('endDate', $date);
+    }
+
+    /** @return $this */
+    public function location(SchemaType|string $location): static
+    {
+        return $this->set('location', $location);
+    }
+
+    /** @return $this */
+    public function instructor(SchemaType $instructor): static
+    {
+        return $this->set('instructor', $instructor);
+    }
+
+    /** @return $this */
+    public function inLanguage(string $language): static
+    {
+        return $this->set('inLanguage', $language);
+    }
+
+    /**
+     * @param SchemaType|SchemaType[] $offers
+     * @return $this
+     */
+    public function offers(SchemaType|array $offers): static
+    {
+        return $this->set('offers', $offers);
+    }
+
+    /** @return $this */
+    public function courseSchedule(SchemaType $schedule): static
+    {
+        return $this->set('courseSchedule', $schedule);
+    }
+}

--- a/src/Seo/Schema/Type/Event.php
+++ b/src/Seo/Schema/Type/Event.php
@@ -13,6 +13,11 @@ class Event extends SchemaType
         parent::__construct('Event');
     }
 
+    protected function getRequiredProperties(): array
+    {
+        return ['name', 'startDate', 'location'];
+    }
+
     /** @return $this */
     public function name(string $name): static
     {

--- a/src/Seo/Schema/Type/Event.php
+++ b/src/Seo/Schema/Type/Event.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Event extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Event');
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function description(string $description): static
+    {
+        return $this->set('description', $description);
+    }
+
+    /** @return $this */
+    public function startDate(string $date): static
+    {
+        return $this->set('startDate', $date);
+    }
+
+    /** @return $this */
+    public function endDate(string $date): static
+    {
+        return $this->set('endDate', $date);
+    }
+
+    /** @return $this */
+    public function location(SchemaType|string $location): static
+    {
+        return $this->set('location', $location);
+    }
+
+    /** @return $this */
+    public function organizer(SchemaType $organizer): static
+    {
+        return $this->set('organizer', $organizer);
+    }
+
+    /** @return $this */
+    public function performer(SchemaType $performer): static
+    {
+        return $this->set('performer', $performer);
+    }
+
+    /** @return $this */
+    public function image(string|SchemaType $image): static
+    {
+        return $this->set('image', $image);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+
+    /**
+     * @param SchemaType|SchemaType[] $offers
+     * @return $this
+     */
+    public function offers(SchemaType|array $offers): static
+    {
+        return $this->set('offers', $offers);
+    }
+
+    /** @return $this */
+    public function eventStatus(string $status): static
+    {
+        return $this->set('eventStatus', $status);
+    }
+
+    /** @return $this */
+    public function eventAttendanceMode(string $mode): static
+    {
+        return $this->set('eventAttendanceMode', $mode);
+    }
+
+    /** @return $this */
+    public function previousStartDate(string $date): static
+    {
+        return $this->set('previousStartDate', $date);
+    }
+
+    /** @return $this */
+    public function doorTime(string $time): static
+    {
+        return $this->set('doorTime', $time);
+    }
+
+    /** @return $this */
+    public function inLanguage(string $language): static
+    {
+        return $this->set('inLanguage', $language);
+    }
+
+    /** @return $this */
+    public function isAccessibleForFree(bool $free): static
+    {
+        return $this->set('isAccessibleForFree', $free);
+    }
+}

--- a/src/Seo/Schema/Type/FAQPage.php
+++ b/src/Seo/Schema/Type/FAQPage.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class FAQPage extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('FAQPage');
+    }
+
+    /**
+     * @param SchemaType[] $questions Question instances
+     * @return $this
+     */
+    public function mainEntity(array $questions): static
+    {
+        return $this->set('mainEntity', $questions);
+    }
+}

--- a/src/Seo/Schema/Type/FAQPage.php
+++ b/src/Seo/Schema/Type/FAQPage.php
@@ -13,6 +13,11 @@ class FAQPage extends SchemaType
         parent::__construct('FAQPage');
     }
 
+    protected function getRequiredProperties(): array
+    {
+        return ['mainEntity'];
+    }
+
     /**
      * @param SchemaType[] $questions Question instances
      * @return $this

--- a/src/Seo/Schema/Type/GeoCoordinates.php
+++ b/src/Seo/Schema/Type/GeoCoordinates.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class GeoCoordinates extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('GeoCoordinates');
+    }
+
+    /** @return $this */
+    public function latitude(float $latitude): static
+    {
+        return $this->set('latitude', $latitude);
+    }
+
+    /** @return $this */
+    public function longitude(float $longitude): static
+    {
+        return $this->set('longitude', $longitude);
+    }
+}

--- a/src/Seo/Schema/Type/ImageObject.php
+++ b/src/Seo/Schema/Type/ImageObject.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class ImageObject extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('ImageObject');
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+
+    /** @return $this */
+    public function width(int $width): static
+    {
+        return $this->set('width', $width);
+    }
+
+    /** @return $this */
+    public function height(int $height): static
+    {
+        return $this->set('height', $height);
+    }
+
+    /** @return $this */
+    public function caption(string $caption): static
+    {
+        return $this->set('caption', $caption);
+    }
+}

--- a/src/Seo/Schema/Type/JobPosting.php
+++ b/src/Seo/Schema/Type/JobPosting.php
@@ -13,6 +13,11 @@ class JobPosting extends SchemaType
         parent::__construct('JobPosting');
     }
 
+    protected function getRequiredProperties(): array
+    {
+        return ['title', 'description', 'datePosted', 'hiringOrganization'];
+    }
+
     /** @return $this */
     public function title(string $title): static
     {

--- a/src/Seo/Schema/Type/JobPosting.php
+++ b/src/Seo/Schema/Type/JobPosting.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class JobPosting extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('JobPosting');
+    }
+
+    /** @return $this */
+    public function title(string $title): static
+    {
+        return $this->set('title', $title);
+    }
+
+    /** @return $this */
+    public function description(string $description): static
+    {
+        return $this->set('description', $description);
+    }
+
+    /** @return $this */
+    public function datePosted(string $date): static
+    {
+        return $this->set('datePosted', $date);
+    }
+
+    /** @return $this */
+    public function validThrough(string $date): static
+    {
+        return $this->set('validThrough', $date);
+    }
+
+    /** @return $this */
+    public function hiringOrganization(SchemaType $organization): static
+    {
+        return $this->set('hiringOrganization', $organization);
+    }
+
+    /** @return $this */
+    public function jobLocation(SchemaType $location): static
+    {
+        return $this->set('jobLocation', $location);
+    }
+
+    /** @return $this */
+    public function baseSalary(SchemaType $salary): static
+    {
+        return $this->set('baseSalary', $salary);
+    }
+
+    /** @return $this */
+    public function employmentType(string|array $type): static
+    {
+        return $this->set('employmentType', $type);
+    }
+
+    /** @return $this */
+    public function jobLocationType(string $type): static
+    {
+        return $this->set('jobLocationType', $type);
+    }
+
+    /** @return $this */
+    public function applicantLocationRequirements(SchemaType $requirements): static
+    {
+        return $this->set('applicantLocationRequirements', $requirements);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+
+    /** @return $this */
+    public function identifier(SchemaType|string $identifier): static
+    {
+        return $this->set('identifier', $identifier);
+    }
+
+    /** @return $this */
+    public function directApply(bool $direct): static
+    {
+        return $this->set('directApply', $direct);
+    }
+
+    /** @return $this */
+    public function industry(string $industry): static
+    {
+        return $this->set('industry', $industry);
+    }
+
+    /** @return $this */
+    public function qualifications(string $qualifications): static
+    {
+        return $this->set('qualifications', $qualifications);
+    }
+
+    /** @return $this */
+    public function responsibilities(string $responsibilities): static
+    {
+        return $this->set('responsibilities', $responsibilities);
+    }
+
+    /** @return $this */
+    public function skills(string $skills): static
+    {
+        return $this->set('skills', $skills);
+    }
+
+    /** @return $this */
+    public function experienceRequirements(string|SchemaType $requirements): static
+    {
+        return $this->set('experienceRequirements', $requirements);
+    }
+
+    /** @return $this */
+    public function educationRequirements(string|SchemaType $requirements): static
+    {
+        return $this->set('educationRequirements', $requirements);
+    }
+}

--- a/src/Seo/Schema/Type/ListItem.php
+++ b/src/Seo/Schema/Type/ListItem.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class ListItem extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('ListItem');
+    }
+
+    /** @return $this */
+    public function position(int $position): static
+    {
+        return $this->set('position', $position);
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('item', $url);
+    }
+}

--- a/src/Seo/Schema/Type/LocalBusiness.php
+++ b/src/Seo/Schema/Type/LocalBusiness.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class LocalBusiness extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('LocalBusiness');
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+
+    /** @return $this */
+    public function logo(string|SchemaType $logo): static
+    {
+        return $this->set('logo', $logo);
+    }
+
+    /** @return $this */
+    public function image(string|SchemaType $image): static
+    {
+        return $this->set('image', $image);
+    }
+
+    /** @return $this */
+    public function description(string $description): static
+    {
+        return $this->set('description', $description);
+    }
+
+    /** @return $this */
+    public function telephone(string $telephone): static
+    {
+        return $this->set('telephone', $telephone);
+    }
+
+    /** @return $this */
+    public function email(string $email): static
+    {
+        return $this->set('email', $email);
+    }
+
+    /** @return $this */
+    public function address(SchemaType $address): static
+    {
+        return $this->set('address', $address);
+    }
+
+    /** @return $this */
+    public function priceRange(string $priceRange): static
+    {
+        return $this->set('priceRange', $priceRange);
+    }
+
+    /** @return $this */
+    public function openingHours(string $openingHours): static
+    {
+        return $this->set('openingHours', $openingHours);
+    }
+
+    /** @return $this */
+    public function geo(SchemaType $geo): static
+    {
+        return $this->set('geo', $geo);
+    }
+
+    /**
+     * @param string[] $urls
+     * @return $this
+     */
+    public function sameAs(array $urls): static
+    {
+        return $this->set('sameAs', $urls);
+    }
+}

--- a/src/Seo/Schema/Type/LocalBusiness.php
+++ b/src/Seo/Schema/Type/LocalBusiness.php
@@ -13,6 +13,11 @@ class LocalBusiness extends SchemaType
         parent::__construct('LocalBusiness');
     }
 
+    protected function getRequiredProperties(): array
+    {
+        return ['name', 'address'];
+    }
+
     /** @return $this */
     public function name(string $name): static
     {

--- a/src/Seo/Schema/Type/MerchantReturnPolicy.php
+++ b/src/Seo/Schema/Type/MerchantReturnPolicy.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class MerchantReturnPolicy extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('MerchantReturnPolicy');
+    }
+
+    /** @return $this */
+    public function applicableCountry(string $country): static
+    {
+        return $this->set('applicableCountry', $country);
+    }
+
+    /** @return $this */
+    public function returnPolicyCategory(string $category): static
+    {
+        return $this->set('returnPolicyCategory', $category);
+    }
+
+    /** @return $this */
+    public function merchantReturnDays(int $days): static
+    {
+        return $this->set('merchantReturnDays', $days);
+    }
+
+    /** @return $this */
+    public function returnMethod(string $method): static
+    {
+        return $this->set('returnMethod', $method);
+    }
+
+    /** @return $this */
+    public function returnFees(string $fees): static
+    {
+        return $this->set('returnFees', $fees);
+    }
+}

--- a/src/Seo/Schema/Type/MonetaryAmount.php
+++ b/src/Seo/Schema/Type/MonetaryAmount.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class MonetaryAmount extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('MonetaryAmount');
+    }
+
+    /** @return $this */
+    public function currency(string $currency): static
+    {
+        return $this->set('currency', $currency);
+    }
+
+    /** @return $this */
+    public function value(float|int|SchemaType $value): static
+    {
+        return $this->set('value', $value);
+    }
+
+    /** @return $this */
+    public function minValue(float|int $value): static
+    {
+        return $this->set('minValue', $value);
+    }
+
+    /** @return $this */
+    public function maxValue(float|int $value): static
+    {
+        return $this->set('maxValue', $value);
+    }
+}

--- a/src/Seo/Schema/Type/Offer.php
+++ b/src/Seo/Schema/Type/Offer.php
@@ -13,6 +13,11 @@ class Offer extends SchemaType
         parent::__construct('Offer');
     }
 
+    protected function getRequiredProperties(): array
+    {
+        return ['price', 'priceCurrency'];
+    }
+
     /** @return $this */
     public function price(string|float|int $price): static
     {

--- a/src/Seo/Schema/Type/Offer.php
+++ b/src/Seo/Schema/Type/Offer.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Offer extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Offer');
+    }
+
+    /** @return $this */
+    public function price(string|float|int $price): static
+    {
+        return $this->set('price', $price);
+    }
+
+    /** @return $this */
+    public function priceCurrency(string $currency): static
+    {
+        return $this->set('priceCurrency', $currency);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+
+    /** @return $this */
+    public function availability(string $availability): static
+    {
+        return $this->set('availability', $availability);
+    }
+
+    /** @return $this */
+    public function validFrom(string $date): static
+    {
+        return $this->set('validFrom', $date);
+    }
+
+    /** @return $this */
+    public function validThrough(string $date): static
+    {
+        return $this->set('validThrough', $date);
+    }
+
+    /** @return $this */
+    public function category(string $category): static
+    {
+        return $this->set('category', $category);
+    }
+}

--- a/src/Seo/Schema/Type/OfferShippingDetails.php
+++ b/src/Seo/Schema/Type/OfferShippingDetails.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class OfferShippingDetails extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('OfferShippingDetails');
+    }
+
+    /** @return $this */
+    public function shippingRate(SchemaType $rate): static
+    {
+        return $this->set('shippingRate', $rate);
+    }
+
+    /** @return $this */
+    public function shippingDestination(SchemaType $destination): static
+    {
+        return $this->set('shippingDestination', $destination);
+    }
+
+    /** @return $this */
+    public function deliveryTime(SchemaType $time): static
+    {
+        return $this->set('deliveryTime', $time);
+    }
+}

--- a/src/Seo/Schema/Type/Organization.php
+++ b/src/Seo/Schema/Type/Organization.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Organization extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Organization');
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+
+    /** @return $this */
+    public function logo(string|SchemaType $logo): static
+    {
+        return $this->set('logo', $logo);
+    }
+
+    /**
+     * @param string[] $urls
+     * @return $this
+     */
+    public function sameAs(array $urls): static
+    {
+        return $this->set('sameAs', $urls);
+    }
+
+    /** @return $this */
+    public function description(string $description): static
+    {
+        return $this->set('description', $description);
+    }
+
+    /** @return $this */
+    public function email(string $email): static
+    {
+        return $this->set('email', $email);
+    }
+
+    /** @return $this */
+    public function telephone(string $telephone): static
+    {
+        return $this->set('telephone', $telephone);
+    }
+
+    /** @return $this */
+    public function address(SchemaType $address): static
+    {
+        return $this->set('address', $address);
+    }
+}

--- a/src/Seo/Schema/Type/Person.php
+++ b/src/Seo/Schema/Type/Person.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Person extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Person');
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+
+    /** @return $this */
+    public function email(string $email): static
+    {
+        return $this->set('email', $email);
+    }
+
+    /** @return $this */
+    public function image(string|SchemaType $image): static
+    {
+        return $this->set('image', $image);
+    }
+
+    /**
+     * @param string[] $urls
+     * @return $this
+     */
+    public function sameAs(array $urls): static
+    {
+        return $this->set('sameAs', $urls);
+    }
+}

--- a/src/Seo/Schema/Type/Place.php
+++ b/src/Seo/Schema/Type/Place.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Place extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Place');
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function address(SchemaType|string $address): static
+    {
+        return $this->set('address', $address);
+    }
+
+    /** @return $this */
+    public function geo(SchemaType $geo): static
+    {
+        return $this->set('geo', $geo);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+}

--- a/src/Seo/Schema/Type/PostalAddress.php
+++ b/src/Seo/Schema/Type/PostalAddress.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class PostalAddress extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('PostalAddress');
+    }
+
+    /** @return $this */
+    public function streetAddress(string $street): static
+    {
+        return $this->set('streetAddress', $street);
+    }
+
+    /** @return $this */
+    public function addressLocality(string $locality): static
+    {
+        return $this->set('addressLocality', $locality);
+    }
+
+    /** @return $this */
+    public function addressRegion(string $region): static
+    {
+        return $this->set('addressRegion', $region);
+    }
+
+    /** @return $this */
+    public function postalCode(string $postalCode): static
+    {
+        return $this->set('postalCode', $postalCode);
+    }
+
+    /** @return $this */
+    public function addressCountry(string $country): static
+    {
+        return $this->set('addressCountry', $country);
+    }
+}

--- a/src/Seo/Schema/Type/Product.php
+++ b/src/Seo/Schema/Type/Product.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Product extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Product');
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function description(string $description): static
+    {
+        return $this->set('description', $description);
+    }
+
+    /** @return $this */
+    public function image(string|SchemaType|array $image): static
+    {
+        return $this->set('image', $image);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+
+    /** @return $this */
+    public function sku(string $sku): static
+    {
+        return $this->set('sku', $sku);
+    }
+
+    /** @return $this */
+    public function gtin(string $gtin): static
+    {
+        return $this->set('gtin', $gtin);
+    }
+
+    /** @return $this */
+    public function gtin13(string $gtin13): static
+    {
+        return $this->set('gtin13', $gtin13);
+    }
+
+    /** @return $this */
+    public function mpn(string $mpn): static
+    {
+        return $this->set('mpn', $mpn);
+    }
+
+    /** @return $this */
+    public function brand(SchemaType $brand): static
+    {
+        return $this->set('brand', $brand);
+    }
+
+    /** @return $this */
+    public function color(string $color): static
+    {
+        return $this->set('color', $color);
+    }
+
+    /** @return $this */
+    public function size(string $size): static
+    {
+        return $this->set('size', $size);
+    }
+
+    /** @return $this */
+    public function material(string $material): static
+    {
+        return $this->set('material', $material);
+    }
+
+    /**
+     * @param SchemaType|SchemaType[] $offers
+     * @return $this
+     */
+    public function offers(SchemaType|array $offers): static
+    {
+        return $this->set('offers', $offers);
+    }
+
+    /** @return $this */
+    public function aggregateRating(SchemaType $rating): static
+    {
+        return $this->set('aggregateRating', $rating);
+    }
+
+    /**
+     * @param SchemaType|SchemaType[] $reviews
+     * @return $this
+     */
+    public function review(SchemaType|array $reviews): static
+    {
+        return $this->set('review', $reviews);
+    }
+
+    /** @return $this */
+    public function category(string $category): static
+    {
+        return $this->set('category', $category);
+    }
+}

--- a/src/Seo/Schema/Type/Product.php
+++ b/src/Seo/Schema/Type/Product.php
@@ -13,6 +13,11 @@ class Product extends SchemaType
         parent::__construct('Product');
     }
 
+    protected function getRequiredProperties(): array
+    {
+        return ['name', 'image', 'offers'];
+    }
+
     /** @return $this */
     public function name(string $name): static
     {

--- a/src/Seo/Schema/Type/Question.php
+++ b/src/Seo/Schema/Type/Question.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Question extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Question');
+    }
+
+    /** @return $this */
+    public function name(string $question): static
+    {
+        return $this->set('name', $question);
+    }
+
+    /** @return $this */
+    public function acceptedAnswer(SchemaType $answer): static
+    {
+        return $this->set('acceptedAnswer', $answer);
+    }
+
+    /**
+     * @param SchemaType[] $answers
+     * @return $this
+     */
+    public function suggestedAnswer(array $answers): static
+    {
+        return $this->set('suggestedAnswer', $answers);
+    }
+}

--- a/src/Seo/Schema/Type/Rating.php
+++ b/src/Seo/Schema/Type/Rating.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Rating extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Rating');
+    }
+
+    /** @return $this */
+    public function ratingValue(float|string $value): static
+    {
+        return $this->set('ratingValue', $value);
+    }
+
+    /** @return $this */
+    public function bestRating(float|string $value): static
+    {
+        return $this->set('bestRating', $value);
+    }
+
+    /** @return $this */
+    public function worstRating(float|string $value): static
+    {
+        return $this->set('worstRating', $value);
+    }
+}

--- a/src/Seo/Schema/Type/Review.php
+++ b/src/Seo/Schema/Type/Review.php
@@ -13,6 +13,11 @@ class Review extends SchemaType
         parent::__construct('Review');
     }
 
+    protected function getRequiredProperties(): array
+    {
+        return ['itemReviewed', 'reviewRating', 'author'];
+    }
+
     /** @return $this */
     public function itemReviewed(SchemaType $item): static
     {

--- a/src/Seo/Schema/Type/Review.php
+++ b/src/Seo/Schema/Type/Review.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class Review extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('Review');
+    }
+
+    /** @return $this */
+    public function itemReviewed(SchemaType $item): static
+    {
+        return $this->set('itemReviewed', $item);
+    }
+
+    /** @return $this */
+    public function reviewRating(SchemaType $rating): static
+    {
+        return $this->set('reviewRating', $rating);
+    }
+
+    /** @return $this */
+    public function author(SchemaType|string $author): static
+    {
+        return $this->set('author', $author);
+    }
+
+    /** @return $this */
+    public function datePublished(string $date): static
+    {
+        return $this->set('datePublished', $date);
+    }
+
+    /** @return $this */
+    public function reviewBody(string $body): static
+    {
+        return $this->set('reviewBody', $body);
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function publisher(SchemaType $publisher): static
+    {
+        return $this->set('publisher', $publisher);
+    }
+}

--- a/src/Seo/Schema/Type/SearchAction.php
+++ b/src/Seo/Schema/Type/SearchAction.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class SearchAction extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('SearchAction');
+    }
+
+    /** @return $this */
+    public function target(string $urlTemplate): static
+    {
+        return $this->set('target', $urlTemplate);
+    }
+
+    /** @return $this */
+    public function queryInput(string $input): static
+    {
+        return $this->set('query-input', $input);
+    }
+}

--- a/src/Seo/Schema/Type/VideoObject.php
+++ b/src/Seo/Schema/Type/VideoObject.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class VideoObject extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('VideoObject');
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function description(string $description): static
+    {
+        return $this->set('description', $description);
+    }
+
+    /** @return $this */
+    public function thumbnailUrl(string|array $url): static
+    {
+        return $this->set('thumbnailUrl', $url);
+    }
+
+    /** @return $this */
+    public function uploadDate(string $date): static
+    {
+        return $this->set('uploadDate', $date);
+    }
+
+    /** @return $this */
+    public function duration(string $duration): static
+    {
+        return $this->set('duration', $duration);
+    }
+
+    /** @return $this */
+    public function contentUrl(string $url): static
+    {
+        return $this->set('contentUrl', $url);
+    }
+
+    /** @return $this */
+    public function embedUrl(string $url): static
+    {
+        return $this->set('embedUrl', $url);
+    }
+
+    /** @return $this */
+    public function expires(string $date): static
+    {
+        return $this->set('expires', $date);
+    }
+
+    /** @return $this */
+    public function interactionStatistic(SchemaType $stat): static
+    {
+        return $this->set('interactionStatistic', $stat);
+    }
+
+    /**
+     * @param SchemaType|SchemaType[] $parts Clip instances for key moments
+     * @return $this
+     */
+    public function hasPart(SchemaType|array $parts): static
+    {
+        return $this->set('hasPart', $parts);
+    }
+
+    /** @return $this */
+    public function publication(SchemaType $event): static
+    {
+        return $this->set('publication', $event);
+    }
+
+    /** @return $this */
+    public function regionsAllowed(string|array $regions): static
+    {
+        return $this->set('regionsAllowed', $regions);
+    }
+}

--- a/src/Seo/Schema/Type/VideoObject.php
+++ b/src/Seo/Schema/Type/VideoObject.php
@@ -13,6 +13,11 @@ class VideoObject extends SchemaType
         parent::__construct('VideoObject');
     }
 
+    protected function getRequiredProperties(): array
+    {
+        return ['name', 'thumbnailUrl', 'uploadDate'];
+    }
+
     /** @return $this */
     public function name(string $name): static
     {

--- a/src/Seo/Schema/Type/VirtualLocation.php
+++ b/src/Seo/Schema/Type/VirtualLocation.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class VirtualLocation extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('VirtualLocation');
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+}

--- a/src/Seo/Schema/Type/WebSite.php
+++ b/src/Seo/Schema/Type/WebSite.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Schema\Type;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+
+class WebSite extends SchemaType
+{
+    public function __construct()
+    {
+        parent::__construct('WebSite');
+    }
+
+    /** @return $this */
+    public function name(string $name): static
+    {
+        return $this->set('name', $name);
+    }
+
+    /** @return $this */
+    public function url(string $url): static
+    {
+        return $this->set('url', $url);
+    }
+
+    /** @return $this */
+    public function description(string $description): static
+    {
+        return $this->set('description', $description);
+    }
+
+    /** @return $this */
+    public function publisher(SchemaType $publisher): static
+    {
+        return $this->set('publisher', $publisher);
+    }
+
+    /** @return $this */
+    public function inLanguage(string $language): static
+    {
+        return $this->set('inLanguage', $language);
+    }
+
+    /** @return $this */
+    public function potentialAction(SchemaType $action): static
+    {
+        return $this->set('potentialAction', $action);
+    }
+}

--- a/src/Seo/SeoConfig.php
+++ b/src/Seo/SeoConfig.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo;
+
+/**
+ * Loads SEO configuration from the project's config/seo.php file.
+ *
+ * Expected format:
+ *
+ *   return [
+ *       'schema' => [
+ *           'post_type_map' => [
+ *               'post'      => ArticleSchemaGenerator::class,
+ *               'formation' => CourseSchemaGenerator::class,
+ *           ],
+ *           'disable_plugin_schema' => true,
+ *       ],
+ *   ];
+ */
+class SeoConfig
+{
+    /** @var array<string, mixed> */
+    private array $config;
+
+    /**
+     * @param string $themeDirectory The project/theme root directory
+     */
+    public function __construct(string $themeDirectory)
+    {
+        $configFile = rtrim($themeDirectory, '/') . '/config/seo.php';
+
+        if (\file_exists($configFile)) {
+            $loaded = require $configFile;
+            $this->config = \is_array($loaded) ? $loaded : [];
+        } else {
+            $this->config = [];
+        }
+    }
+
+    /**
+     * Get the full config array.
+     *
+     * @return array<string, mixed>
+     */
+    public function all(): array
+    {
+        return $this->config;
+    }
+
+    /**
+     * Get a nested config value using dot notation.
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $keys = explode('.', $key);
+        $value = $this->config;
+
+        foreach ($keys as $segment) {
+            if (!\is_array($value) || !array_key_exists($segment, $value)) {
+                return $default;
+            }
+
+            $value = $value[$segment];
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the post_type → generator class mapping.
+     *
+     * @return array<string, class-string>
+     */
+    public function getPostTypeMap(): array
+    {
+        $map = $this->get('schema.post_type_map', []);
+
+        return \is_array($map) ? $map : [];
+    }
+
+    /**
+     * Whether the framework should disable the SEO plugin's native schema output.
+     */
+    public function shouldDisablePluginSchema(): bool
+    {
+        return (bool) $this->get('schema.disable_plugin_schema', true);
+    }
+}

--- a/src/Seo/SeoExtension.php
+++ b/src/Seo/SeoExtension.php
@@ -14,7 +14,7 @@ class SeoExtension implements ExtensionInterface
         return [
             'dir' => __DIR__,
             'namespace' => 'BackTo\\Framework\\Seo\\',
-            'exclude' => '{Tests,Contracts,Schema/Type,Schema/SchemaType.php}',
+            'exclude' => '{Tests,Contracts,Schema/Type,Schema/SchemaType.php,Schema/SchemaRef.php}',
         ];
     }
 

--- a/src/Seo/SeoExtension.php
+++ b/src/Seo/SeoExtension.php
@@ -14,7 +14,7 @@ class SeoExtension implements ExtensionInterface
         return [
             'dir' => __DIR__,
             'namespace' => 'BackTo\\Framework\\Seo\\',
-            'exclude' => '{Tests,Contracts}',
+            'exclude' => '{Tests,Contracts,Schema/Type,Schema/SchemaType.php}',
         ];
     }
 

--- a/src/Seo/Tests/DisablePluginSchemaTest.php
+++ b/src/Seo/Tests/DisablePluginSchemaTest.php
@@ -7,6 +7,7 @@ namespace BackTo\Framework\Seo\Tests;
 use BackTo\Framework\Contracts\HookDispatcherInterface;
 use BackTo\Framework\Seo\Actions\DisablePluginSchema;
 use BackTo\Framework\Seo\Contracts\SeoProviderInterface;
+use BackTo\Framework\Seo\SeoConfig;
 use BackTo\Framework\Seo\SeoManager;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,7 @@ class DisablePluginSchemaTest extends TestCase
         $dispatcher->expects($this->never())->method('addFilter');
 
         $manager = new SeoManager();
-        $action = new DisablePluginSchema($manager, $dispatcher);
+        $action = new DisablePluginSchema($manager, $this->createConfigEnabled(), $dispatcher);
         $action->hooks();
     }
 
@@ -34,7 +35,7 @@ class DisablePluginSchemaTest extends TestCase
             ->with('wpseo_json_ld_output', '__return_empty_array');
 
         $manager = new SeoManager([$provider]);
-        $action = new DisablePluginSchema($manager, $dispatcher);
+        $action = new DisablePluginSchema($manager, $this->createConfigEnabled(), $dispatcher);
         $action->hooks();
     }
 
@@ -50,7 +51,7 @@ class DisablePluginSchemaTest extends TestCase
             ->with('seopress_schemas_auto_enabled', '__return_false');
 
         $manager = new SeoManager([$provider]);
-        $action = new DisablePluginSchema($manager, $dispatcher);
+        $action = new DisablePluginSchema($manager, $this->createConfigEnabled(), $dispatcher);
         $action->hooks();
     }
 
@@ -64,7 +65,32 @@ class DisablePluginSchemaTest extends TestCase
         $dispatcher->expects($this->never())->method('addFilter');
 
         $manager = new SeoManager([$provider]);
-        $action = new DisablePluginSchema($manager, $dispatcher);
+        $action = new DisablePluginSchema($manager, $this->createConfigEnabled(), $dispatcher);
         $action->hooks();
+    }
+
+    public function testDoesNothingWhenConfigDisabled(): void
+    {
+        $provider = $this->createMock(SeoProviderInterface::class);
+        $provider->method('isActive')->willReturn(true);
+        $provider->method('getName')->willReturn('yoast');
+
+        $dispatcher = $this->createMock(HookDispatcherInterface::class);
+        $dispatcher->expects($this->never())->method('addFilter');
+
+        $config = $this->createMock(SeoConfig::class);
+        $config->method('shouldDisablePluginSchema')->willReturn(false);
+
+        $manager = new SeoManager([$provider]);
+        $action = new DisablePluginSchema($manager, $config, $dispatcher);
+        $action->hooks();
+    }
+
+    private function createConfigEnabled(): SeoConfig
+    {
+        $config = $this->createMock(SeoConfig::class);
+        $config->method('shouldDisablePluginSchema')->willReturn(true);
+
+        return $config;
     }
 }

--- a/src/Seo/Tests/DisablePluginSchemaTest.php
+++ b/src/Seo/Tests/DisablePluginSchemaTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Contracts\HookDispatcherInterface;
+use BackTo\Framework\Seo\Actions\DisablePluginSchema;
+use BackTo\Framework\Seo\Contracts\SeoProviderInterface;
+use BackTo\Framework\Seo\SeoManager;
+use PHPUnit\Framework\TestCase;
+
+class DisablePluginSchemaTest extends TestCase
+{
+    public function testDoesNothingWhenNoProvider(): void
+    {
+        $dispatcher = $this->createMock(HookDispatcherInterface::class);
+        $dispatcher->expects($this->never())->method('addFilter');
+
+        $manager = new SeoManager();
+        $action = new DisablePluginSchema($manager, $dispatcher);
+        $action->hooks();
+    }
+
+    public function testDisablesYoastSchema(): void
+    {
+        $provider = $this->createMock(SeoProviderInterface::class);
+        $provider->method('isActive')->willReturn(true);
+        $provider->method('getName')->willReturn('yoast');
+
+        $dispatcher = $this->createMock(HookDispatcherInterface::class);
+        $dispatcher->expects($this->once())
+            ->method('addFilter')
+            ->with('wpseo_json_ld_output', '__return_empty_array');
+
+        $manager = new SeoManager([$provider]);
+        $action = new DisablePluginSchema($manager, $dispatcher);
+        $action->hooks();
+    }
+
+    public function testDisablesSeoPressSchema(): void
+    {
+        $provider = $this->createMock(SeoProviderInterface::class);
+        $provider->method('isActive')->willReturn(true);
+        $provider->method('getName')->willReturn('seopress');
+
+        $dispatcher = $this->createMock(HookDispatcherInterface::class);
+        $dispatcher->expects($this->once())
+            ->method('addFilter')
+            ->with('seopress_schemas_auto_enabled', '__return_false');
+
+        $manager = new SeoManager([$provider]);
+        $action = new DisablePluginSchema($manager, $dispatcher);
+        $action->hooks();
+    }
+
+    public function testDoesNothingForUnknownProvider(): void
+    {
+        $provider = $this->createMock(SeoProviderInterface::class);
+        $provider->method('isActive')->willReturn(true);
+        $provider->method('getName')->willReturn('rank_math');
+
+        $dispatcher = $this->createMock(HookDispatcherInterface::class);
+        $dispatcher->expects($this->never())->method('addFilter');
+
+        $manager = new SeoManager([$provider]);
+        $action = new DisablePluginSchema($manager, $dispatcher);
+        $action->hooks();
+    }
+}

--- a/src/Seo/Tests/PostTypeSchemaResolverTest.php
+++ b/src/Seo/Tests/PostTypeSchemaResolverTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema\Generator\PostTypeSchemaResolver;
+use BackTo\Framework\Seo\Schema\SchemaType;
+use PHPUnit\Framework\TestCase;
+
+class PostTypeSchemaResolverTest extends TestCase
+{
+    public function testEmptyByDefault(): void
+    {
+        $resolver = new PostTypeSchemaResolver();
+        $this->assertFalse($resolver->supports('post'));
+        $this->assertSame([], $resolver->getGenerators());
+    }
+
+    public function testAddGenerator(): void
+    {
+        $generator = $this->createGenerator(new SchemaType('Article'));
+
+        $resolver = new PostTypeSchemaResolver();
+        $result = $resolver->addGenerator('post', $generator);
+
+        $this->assertSame($resolver, $result);
+        $this->assertTrue($resolver->supports('post'));
+        $this->assertFalse($resolver->supports('page'));
+    }
+
+    public function testConstructorWithGenerators(): void
+    {
+        $resolver = new PostTypeSchemaResolver([
+            'post' => $this->createGenerator(new SchemaType('Article')),
+            'formation' => $this->createGenerator(new SchemaType('Course')),
+        ]);
+
+        $this->assertTrue($resolver->supports('post'));
+        $this->assertTrue($resolver->supports('formation'));
+        $this->assertFalse($resolver->supports('page'));
+    }
+
+    public function testResolveCallsGenerator(): void
+    {
+        $schema = new SchemaType('Article');
+        $generator = $this->createGenerator($schema);
+
+        $resolver = new PostTypeSchemaResolver(['post' => $generator]);
+
+        $result = $resolver->resolve('post', 42);
+
+        $this->assertSame($schema, $result);
+    }
+
+    public function testResolveReturnsNullForUnsupportedType(): void
+    {
+        $resolver = new PostTypeSchemaResolver();
+        $this->assertNull($resolver->resolve('unknown', 1));
+    }
+
+    public function testResolveReturnsNullFromGenerator(): void
+    {
+        $generator = $this->createGenerator(null);
+
+        $resolver = new PostTypeSchemaResolver(['post' => $generator]);
+
+        $this->assertNull($resolver->resolve('post', 999));
+    }
+
+    public function testGetGenerators(): void
+    {
+        $genA = $this->createGenerator(new SchemaType('Article'));
+        $genB = $this->createGenerator(new SchemaType('Course'));
+
+        $resolver = new PostTypeSchemaResolver([
+            'post' => $genA,
+            'formation' => $genB,
+        ]);
+
+        $generators = $resolver->getGenerators();
+
+        $this->assertCount(2, $generators);
+        $this->assertSame($genA, $generators['post']);
+        $this->assertSame($genB, $generators['formation']);
+    }
+
+    private function createGenerator(?SchemaType $returnValue): object
+    {
+        return new class ($returnValue) {
+            public function __construct(private ?SchemaType $returnValue)
+            {
+            }
+
+            public function generate(?int $postId = null): ?SchemaType
+            {
+                return $this->returnValue;
+            }
+        };
+    }
+}

--- a/src/Seo/Tests/RegisterDefaultSchemasTest.php
+++ b/src/Seo/Tests/RegisterDefaultSchemasTest.php
@@ -6,9 +6,9 @@ namespace BackTo\Framework\Seo\Tests;
 
 use BackTo\Framework\Contracts\HookDispatcherInterface;
 use BackTo\Framework\Seo\Hooks\RegisterDefaultSchemas;
-use BackTo\Framework\Seo\Schema\Generator\ArticleSchemaGenerator;
 use BackTo\Framework\Seo\Schema\Generator\BreadcrumbSchemaGenerator;
 use BackTo\Framework\Seo\Schema\Generator\OrganizationSchemaGenerator;
+use BackTo\Framework\Seo\Schema\Generator\PostTypeSchemaResolver;
 use BackTo\Framework\Seo\Schema\Generator\WebSiteSchemaGenerator;
 use BackTo\Framework\Seo\Schema\SchemaManager;
 use BackTo\Framework\Seo\Schema\SchemaType;
@@ -28,7 +28,7 @@ class RegisterDefaultSchemasTest extends TestCase
             $dispatcher,
             $this->createMock(WebSiteSchemaGenerator::class),
             $this->createMock(OrganizationSchemaGenerator::class),
-            $this->createMock(ArticleSchemaGenerator::class),
+            new PostTypeSchemaResolver(),
             $this->createMock(BreadcrumbSchemaGenerator::class),
         );
 
@@ -47,9 +47,6 @@ class RegisterDefaultSchemasTest extends TestCase
         $orgGen->expects($this->once())->method('generate')
             ->willReturn(new SchemaType('Organization'));
 
-        $articleGen = $this->createMock(ArticleSchemaGenerator::class);
-        $articleGen->method('generate')->willReturn(null);
-
         $breadcrumbGen = $this->createMock(BreadcrumbSchemaGenerator::class);
         $breadcrumbGen->method('generate')->willReturn(null);
 
@@ -58,7 +55,7 @@ class RegisterDefaultSchemasTest extends TestCase
             $this->createMock(HookDispatcherInterface::class),
             $webSiteGen,
             $orgGen,
-            $articleGen,
+            new PostTypeSchemaResolver(),
             $breadcrumbGen,
         );
 
@@ -67,37 +64,6 @@ class RegisterDefaultSchemasTest extends TestCase
         $this->assertCount(2, $manager->getSchemas());
         $this->assertSame('WebSite', $manager->getSchemas()[0]->getType());
         $this->assertSame('Organization', $manager->getSchemas()[1]->getType());
-    }
-
-    public function testRegistersArticleWhenAvailable(): void
-    {
-        $manager = new SchemaManager();
-
-        $webSiteGen = $this->createMock(WebSiteSchemaGenerator::class);
-        $webSiteGen->method('generate')->willReturn(new SchemaType('WebSite'));
-
-        $orgGen = $this->createMock(OrganizationSchemaGenerator::class);
-        $orgGen->method('generate')->willReturn(new SchemaType('Organization'));
-
-        $articleGen = $this->createMock(ArticleSchemaGenerator::class);
-        $articleGen->method('generate')->willReturn(new SchemaType('Article'));
-
-        $breadcrumbGen = $this->createMock(BreadcrumbSchemaGenerator::class);
-        $breadcrumbGen->method('generate')->willReturn(null);
-
-        $hook = new RegisterDefaultSchemas(
-            $manager,
-            $this->createMock(HookDispatcherInterface::class),
-            $webSiteGen,
-            $orgGen,
-            $articleGen,
-            $breadcrumbGen,
-        );
-
-        $hook->register();
-
-        $this->assertCount(3, $manager->getSchemas());
-        $this->assertSame('Article', $manager->getSchemas()[2]->getType());
     }
 
     public function testRegistersBreadcrumbWhenAvailable(): void
@@ -110,9 +76,6 @@ class RegisterDefaultSchemasTest extends TestCase
         $orgGen = $this->createMock(OrganizationSchemaGenerator::class);
         $orgGen->method('generate')->willReturn(new SchemaType('Organization'));
 
-        $articleGen = $this->createMock(ArticleSchemaGenerator::class);
-        $articleGen->method('generate')->willReturn(null);
-
         $breadcrumbGen = $this->createMock(BreadcrumbSchemaGenerator::class);
         $breadcrumbGen->method('generate')->willReturn(new SchemaType('BreadcrumbList'));
 
@@ -121,7 +84,7 @@ class RegisterDefaultSchemasTest extends TestCase
             $this->createMock(HookDispatcherInterface::class),
             $webSiteGen,
             $orgGen,
-            $articleGen,
+            new PostTypeSchemaResolver(),
             $breadcrumbGen,
         );
 
@@ -131,7 +94,7 @@ class RegisterDefaultSchemasTest extends TestCase
         $this->assertSame('BreadcrumbList', $manager->getSchemas()[2]->getType());
     }
 
-    public function testRegistersAllFourWhenAvailable(): void
+    public function testSkipsNullBreadcrumb(): void
     {
         $manager = new SchemaManager();
 
@@ -140,44 +103,6 @@ class RegisterDefaultSchemasTest extends TestCase
 
         $orgGen = $this->createMock(OrganizationSchemaGenerator::class);
         $orgGen->method('generate')->willReturn(new SchemaType('Organization'));
-
-        $articleGen = $this->createMock(ArticleSchemaGenerator::class);
-        $articleGen->method('generate')->willReturn(new SchemaType('Article'));
-
-        $breadcrumbGen = $this->createMock(BreadcrumbSchemaGenerator::class);
-        $breadcrumbGen->method('generate')->willReturn(new SchemaType('BreadcrumbList'));
-
-        $hook = new RegisterDefaultSchemas(
-            $manager,
-            $this->createMock(HookDispatcherInterface::class),
-            $webSiteGen,
-            $orgGen,
-            $articleGen,
-            $breadcrumbGen,
-        );
-
-        $hook->register();
-
-        $schemas = $manager->getSchemas();
-        $this->assertCount(4, $schemas);
-        $this->assertSame('WebSite', $schemas[0]->getType());
-        $this->assertSame('Organization', $schemas[1]->getType());
-        $this->assertSame('Article', $schemas[2]->getType());
-        $this->assertSame('BreadcrumbList', $schemas[3]->getType());
-    }
-
-    public function testSkipsNullArticleAndBreadcrumb(): void
-    {
-        $manager = new SchemaManager();
-
-        $webSiteGen = $this->createMock(WebSiteSchemaGenerator::class);
-        $webSiteGen->method('generate')->willReturn(new SchemaType('WebSite'));
-
-        $orgGen = $this->createMock(OrganizationSchemaGenerator::class);
-        $orgGen->method('generate')->willReturn(new SchemaType('Organization'));
-
-        $articleGen = $this->createMock(ArticleSchemaGenerator::class);
-        $articleGen->method('generate')->willReturn(null);
 
         $breadcrumbGen = $this->createMock(BreadcrumbSchemaGenerator::class);
         $breadcrumbGen->method('generate')->willReturn(null);
@@ -187,7 +112,7 @@ class RegisterDefaultSchemasTest extends TestCase
             $this->createMock(HookDispatcherInterface::class),
             $webSiteGen,
             $orgGen,
-            $articleGen,
+            new PostTypeSchemaResolver(),
             $breadcrumbGen,
         );
 

--- a/src/Seo/Tests/RegisterDefaultSchemasTest.php
+++ b/src/Seo/Tests/RegisterDefaultSchemasTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Contracts\HookDispatcherInterface;
+use BackTo\Framework\Seo\Hooks\RegisterDefaultSchemas;
+use BackTo\Framework\Seo\Schema\Generator\ArticleSchemaGenerator;
+use BackTo\Framework\Seo\Schema\Generator\BreadcrumbSchemaGenerator;
+use BackTo\Framework\Seo\Schema\Generator\OrganizationSchemaGenerator;
+use BackTo\Framework\Seo\Schema\Generator\WebSiteSchemaGenerator;
+use BackTo\Framework\Seo\Schema\SchemaManager;
+use BackTo\Framework\Seo\Schema\SchemaType;
+use PHPUnit\Framework\TestCase;
+
+class RegisterDefaultSchemasTest extends TestCase
+{
+    public function testRegistersOnWpHook(): void
+    {
+        $dispatcher = $this->createMock(HookDispatcherInterface::class);
+        $dispatcher->expects($this->once())
+            ->method('addAction')
+            ->with('wp', $this->anything());
+
+        $hook = new RegisterDefaultSchemas(
+            new SchemaManager(),
+            $dispatcher,
+            $this->createMock(WebSiteSchemaGenerator::class),
+            $this->createMock(OrganizationSchemaGenerator::class),
+            $this->createMock(ArticleSchemaGenerator::class),
+            $this->createMock(BreadcrumbSchemaGenerator::class),
+        );
+
+        $hook->hooks();
+    }
+
+    public function testRegistersWebSiteAndOrganizationAlways(): void
+    {
+        $manager = new SchemaManager();
+
+        $webSiteGen = $this->createMock(WebSiteSchemaGenerator::class);
+        $webSiteGen->expects($this->once())->method('generate')
+            ->willReturn(new SchemaType('WebSite'));
+
+        $orgGen = $this->createMock(OrganizationSchemaGenerator::class);
+        $orgGen->expects($this->once())->method('generate')
+            ->willReturn(new SchemaType('Organization'));
+
+        $articleGen = $this->createMock(ArticleSchemaGenerator::class);
+        $articleGen->method('generate')->willReturn(null);
+
+        $breadcrumbGen = $this->createMock(BreadcrumbSchemaGenerator::class);
+        $breadcrumbGen->method('generate')->willReturn(null);
+
+        $hook = new RegisterDefaultSchemas(
+            $manager,
+            $this->createMock(HookDispatcherInterface::class),
+            $webSiteGen,
+            $orgGen,
+            $articleGen,
+            $breadcrumbGen,
+        );
+
+        $hook->register();
+
+        $this->assertCount(2, $manager->getSchemas());
+        $this->assertSame('WebSite', $manager->getSchemas()[0]->getType());
+        $this->assertSame('Organization', $manager->getSchemas()[1]->getType());
+    }
+
+    public function testRegistersArticleWhenAvailable(): void
+    {
+        $manager = new SchemaManager();
+
+        $webSiteGen = $this->createMock(WebSiteSchemaGenerator::class);
+        $webSiteGen->method('generate')->willReturn(new SchemaType('WebSite'));
+
+        $orgGen = $this->createMock(OrganizationSchemaGenerator::class);
+        $orgGen->method('generate')->willReturn(new SchemaType('Organization'));
+
+        $articleGen = $this->createMock(ArticleSchemaGenerator::class);
+        $articleGen->method('generate')->willReturn(new SchemaType('Article'));
+
+        $breadcrumbGen = $this->createMock(BreadcrumbSchemaGenerator::class);
+        $breadcrumbGen->method('generate')->willReturn(null);
+
+        $hook = new RegisterDefaultSchemas(
+            $manager,
+            $this->createMock(HookDispatcherInterface::class),
+            $webSiteGen,
+            $orgGen,
+            $articleGen,
+            $breadcrumbGen,
+        );
+
+        $hook->register();
+
+        $this->assertCount(3, $manager->getSchemas());
+        $this->assertSame('Article', $manager->getSchemas()[2]->getType());
+    }
+
+    public function testRegistersBreadcrumbWhenAvailable(): void
+    {
+        $manager = new SchemaManager();
+
+        $webSiteGen = $this->createMock(WebSiteSchemaGenerator::class);
+        $webSiteGen->method('generate')->willReturn(new SchemaType('WebSite'));
+
+        $orgGen = $this->createMock(OrganizationSchemaGenerator::class);
+        $orgGen->method('generate')->willReturn(new SchemaType('Organization'));
+
+        $articleGen = $this->createMock(ArticleSchemaGenerator::class);
+        $articleGen->method('generate')->willReturn(null);
+
+        $breadcrumbGen = $this->createMock(BreadcrumbSchemaGenerator::class);
+        $breadcrumbGen->method('generate')->willReturn(new SchemaType('BreadcrumbList'));
+
+        $hook = new RegisterDefaultSchemas(
+            $manager,
+            $this->createMock(HookDispatcherInterface::class),
+            $webSiteGen,
+            $orgGen,
+            $articleGen,
+            $breadcrumbGen,
+        );
+
+        $hook->register();
+
+        $this->assertCount(3, $manager->getSchemas());
+        $this->assertSame('BreadcrumbList', $manager->getSchemas()[2]->getType());
+    }
+
+    public function testRegistersAllFourWhenAvailable(): void
+    {
+        $manager = new SchemaManager();
+
+        $webSiteGen = $this->createMock(WebSiteSchemaGenerator::class);
+        $webSiteGen->method('generate')->willReturn(new SchemaType('WebSite'));
+
+        $orgGen = $this->createMock(OrganizationSchemaGenerator::class);
+        $orgGen->method('generate')->willReturn(new SchemaType('Organization'));
+
+        $articleGen = $this->createMock(ArticleSchemaGenerator::class);
+        $articleGen->method('generate')->willReturn(new SchemaType('Article'));
+
+        $breadcrumbGen = $this->createMock(BreadcrumbSchemaGenerator::class);
+        $breadcrumbGen->method('generate')->willReturn(new SchemaType('BreadcrumbList'));
+
+        $hook = new RegisterDefaultSchemas(
+            $manager,
+            $this->createMock(HookDispatcherInterface::class),
+            $webSiteGen,
+            $orgGen,
+            $articleGen,
+            $breadcrumbGen,
+        );
+
+        $hook->register();
+
+        $schemas = $manager->getSchemas();
+        $this->assertCount(4, $schemas);
+        $this->assertSame('WebSite', $schemas[0]->getType());
+        $this->assertSame('Organization', $schemas[1]->getType());
+        $this->assertSame('Article', $schemas[2]->getType());
+        $this->assertSame('BreadcrumbList', $schemas[3]->getType());
+    }
+
+    public function testSkipsNullArticleAndBreadcrumb(): void
+    {
+        $manager = new SchemaManager();
+
+        $webSiteGen = $this->createMock(WebSiteSchemaGenerator::class);
+        $webSiteGen->method('generate')->willReturn(new SchemaType('WebSite'));
+
+        $orgGen = $this->createMock(OrganizationSchemaGenerator::class);
+        $orgGen->method('generate')->willReturn(new SchemaType('Organization'));
+
+        $articleGen = $this->createMock(ArticleSchemaGenerator::class);
+        $articleGen->method('generate')->willReturn(null);
+
+        $breadcrumbGen = $this->createMock(BreadcrumbSchemaGenerator::class);
+        $breadcrumbGen->method('generate')->willReturn(null);
+
+        $hook = new RegisterDefaultSchemas(
+            $manager,
+            $this->createMock(HookDispatcherInterface::class),
+            $webSiteGen,
+            $orgGen,
+            $articleGen,
+            $breadcrumbGen,
+        );
+
+        $hook->register();
+
+        $this->assertCount(2, $manager->getSchemas());
+    }
+}

--- a/src/Seo/Tests/SchemaCourseTest.php
+++ b/src/Seo/Tests/SchemaCourseTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\Type\AggregateRating;
+use BackTo\Framework\Seo\Schema\Type\Course;
+use BackTo\Framework\Seo\Schema\Type\CourseInstance;
+use PHPUnit\Framework\TestCase;
+
+class SchemaCourseTest extends TestCase
+{
+    public function testCourseFactory(): void
+    {
+        $course = Schema::course();
+        $this->assertInstanceOf(Course::class, $course);
+        $this->assertSame('Course', $course->getType());
+    }
+
+    public function testCourseInstanceFactory(): void
+    {
+        $instance = Schema::courseInstance();
+        $this->assertInstanceOf(CourseInstance::class, $instance);
+        $this->assertSame('CourseInstance', $instance->getType());
+    }
+
+    public function testAggregateRatingFactory(): void
+    {
+        $rating = Schema::aggregateRating();
+        $this->assertInstanceOf(AggregateRating::class, $rating);
+        $this->assertSame('AggregateRating', $rating->getType());
+    }
+
+    public function testFullCourseComposition(): void
+    {
+        $course = Schema::course()
+            ->name('Formation WordPress Avancé')
+            ->description('Maîtrisez les hooks, les custom post types et le développement de thèmes.')
+            ->provider(Schema::organization()->name('Acme Formation')->url('https://acme-formation.fr'))
+            ->url('https://acme-formation.fr/formations/wordpress-avance')
+            ->inLanguage('fr')
+            ->courseCode('WP-ADV-01')
+            ->educationalLevel('Intermediate')
+            ->coursePrerequisites(['Bases PHP', 'Connaissance HTML/CSS'])
+            ->timeRequired('PT40H')
+            ->hasCourseInstance([
+                Schema::courseInstance()
+                    ->courseMode('onsite')
+                    ->startDate('2026-09-01')
+                    ->endDate('2026-09-05')
+                    ->location(
+                        Schema::place()
+                            ->name('Centre de formation Acme')
+                            ->address(
+                                Schema::postalAddress()
+                                    ->streetAddress('10 rue de la Paix')
+                                    ->addressLocality('Lyon')
+                                    ->postalCode('69002')
+                                    ->addressCountry('FR')
+                            )
+                    )
+                    ->instructor(Schema::person()->name('Marie Martin'))
+                    ->offers(
+                        Schema::offer()
+                            ->price('1500')
+                            ->priceCurrency('EUR')
+                            ->availability('https://schema.org/InStock')
+                    ),
+                Schema::courseInstance()
+                    ->courseMode('online')
+                    ->startDate('2026-10-15')
+                    ->endDate('2026-10-19')
+                    ->location(Schema::virtualLocation()->url('https://acme-formation.fr/live'))
+                    ->instructor(Schema::person()->name('Marie Martin'))
+                    ->offers(
+                        Schema::offer()
+                            ->price('990')
+                            ->priceCurrency('EUR')
+                    ),
+            ])
+            ->aggregateRating(
+                Schema::aggregateRating()
+                    ->ratingValue(4.7)
+                    ->bestRating(5.0)
+                    ->ratingCount(128)
+                    ->reviewCount(45)
+            );
+
+        $array = $course->toArray();
+
+        $this->assertSame('Course', $array['@type']);
+        $this->assertSame('Formation WordPress Avancé', $array['name']);
+        $this->assertSame('Organization', $array['provider']['@type']);
+        $this->assertSame('fr', $array['inLanguage']);
+        $this->assertSame('WP-ADV-01', $array['courseCode']);
+        $this->assertSame(['Bases PHP', 'Connaissance HTML/CSS'], $array['coursePrerequisites']);
+        $this->assertSame('PT40H', $array['timeRequired']);
+
+        // Course instances
+        $this->assertCount(2, $array['hasCourseInstance']);
+        $this->assertSame('CourseInstance', $array['hasCourseInstance'][0]['@type']);
+        $this->assertSame('onsite', $array['hasCourseInstance'][0]['courseMode']);
+        $this->assertSame('Place', $array['hasCourseInstance'][0]['location']['@type']);
+        $this->assertSame('online', $array['hasCourseInstance'][1]['courseMode']);
+        $this->assertSame('VirtualLocation', $array['hasCourseInstance'][1]['location']['@type']);
+
+        // Pricing
+        $this->assertSame('1500', $array['hasCourseInstance'][0]['offers']['price']);
+        $this->assertSame('990', $array['hasCourseInstance'][1]['offers']['price']);
+
+        // Rating
+        $this->assertSame('AggregateRating', $array['aggregateRating']['@type']);
+        $this->assertSame(4.7, $array['aggregateRating']['ratingValue']);
+        $this->assertSame(128, $array['aggregateRating']['ratingCount']);
+    }
+
+    public function testSimpleCourse(): void
+    {
+        $course = Schema::course()
+            ->name('Initiation SEO')
+            ->description('Les bases du référencement naturel')
+            ->provider(Schema::organization()->name('Acme'))
+            ->offers(Schema::offer()->price('0')->priceCurrency('EUR'));
+
+        $array = $course->toArray();
+
+        $this->assertSame('Course', $array['@type']);
+        $this->assertSame('Initiation SEO', $array['name']);
+        $this->assertSame('Offer', $array['offers']['@type']);
+        $this->assertSame('0', $array['offers']['price']);
+    }
+
+    public function testCourseRendersValidJsonLd(): void
+    {
+        $manager = new Schema\SchemaManager();
+        $manager->add(
+            Schema::course()
+                ->name('Formation Test')
+                ->provider(Schema::organization()->name('Test Org'))
+        );
+
+        $output = $manager->render();
+
+        $this->assertStringContainsString('"@type": "Course"', $output);
+        $this->assertStringContainsString('"@context": "https://schema.org"', $output);
+    }
+}

--- a/src/Seo/Tests/SchemaEventTest.php
+++ b/src/Seo/Tests/SchemaEventTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\Type\Event;
+use BackTo\Framework\Seo\Schema\Type\Offer;
+use BackTo\Framework\Seo\Schema\Type\Place;
+use BackTo\Framework\Seo\Schema\Type\VirtualLocation;
+use PHPUnit\Framework\TestCase;
+
+class SchemaEventTest extends TestCase
+{
+    public function testEventFactory(): void
+    {
+        $event = Schema::event();
+        $this->assertInstanceOf(Event::class, $event);
+        $this->assertSame('Event', $event->getType());
+    }
+
+    public function testPhysicalEvent(): void
+    {
+        $event = Schema::event()
+            ->name('Conférence WordPress')
+            ->description('Une journée dédiée à WordPress')
+            ->startDate('2026-06-15T09:00:00+02:00')
+            ->endDate('2026-06-15T18:00:00+02:00')
+            ->location(
+                Schema::place()
+                    ->name('Palais des Congrès')
+                    ->address(
+                        Schema::postalAddress()
+                            ->streetAddress('2 Place de la Porte Maillot')
+                            ->addressLocality('Paris')
+                            ->postalCode('75017')
+                            ->addressCountry('FR')
+                    )
+                    ->geo(Schema::geoCoordinates()->latitude(48.8789)->longitude(2.2831))
+            )
+            ->organizer(Schema::organization()->name('WP France'))
+            ->image('https://example.com/event.jpg')
+            ->url('https://example.com/events/wp-conf')
+            ->offers(
+                Schema::offer()
+                    ->price('49.99')
+                    ->priceCurrency('EUR')
+                    ->availability('https://schema.org/InStock')
+                    ->validFrom('2026-01-01')
+                    ->url('https://example.com/events/wp-conf/tickets')
+            )
+            ->eventStatus('https://schema.org/EventScheduled')
+            ->eventAttendanceMode('https://schema.org/OfflineEventAttendanceMode');
+
+        $array = $event->toArray();
+
+        $this->assertSame('Event', $array['@type']);
+        $this->assertSame('Conférence WordPress', $array['name']);
+        $this->assertSame('2026-06-15T09:00:00+02:00', $array['startDate']);
+        $this->assertSame('Place', $array['location']['@type']);
+        $this->assertSame('PostalAddress', $array['location']['address']['@type']);
+        $this->assertSame('GeoCoordinates', $array['location']['geo']['@type']);
+        $this->assertSame(48.8789, $array['location']['geo']['latitude']);
+        $this->assertSame('Organization', $array['organizer']['@type']);
+        $this->assertSame('Offer', $array['offers']['@type']);
+        $this->assertSame('49.99', $array['offers']['price']);
+    }
+
+    public function testOnlineEvent(): void
+    {
+        $event = Schema::event()
+            ->name('Webinaire SEO')
+            ->startDate('2026-04-01T14:00:00+02:00')
+            ->endDate('2026-04-01T15:30:00+02:00')
+            ->location(Schema::virtualLocation()->url('https://zoom.us/j/123456'))
+            ->eventAttendanceMode('https://schema.org/OnlineEventAttendanceMode')
+            ->isAccessibleForFree(true);
+
+        $array = $event->toArray();
+
+        $this->assertSame('VirtualLocation', $array['location']['@type']);
+        $this->assertSame('https://zoom.us/j/123456', $array['location']['url']);
+        $this->assertTrue($array['isAccessibleForFree']);
+    }
+
+    public function testEventWithMultipleOffers(): void
+    {
+        $event = Schema::event()
+            ->name('Festival')
+            ->startDate('2026-07-01')
+            ->offers([
+                Schema::offer()->price('25')->priceCurrency('EUR')->category('Early Bird'),
+                Schema::offer()->price('45')->priceCurrency('EUR')->category('Standard'),
+                Schema::offer()->price('80')->priceCurrency('EUR')->category('VIP'),
+            ]);
+
+        $array = $event->toArray();
+
+        $this->assertCount(3, $array['offers']);
+        $this->assertSame('25', $array['offers'][0]['price']);
+        $this->assertSame('VIP', $array['offers'][2]['category']);
+    }
+
+    public function testPlaceFactory(): void
+    {
+        $place = Schema::place();
+        $this->assertInstanceOf(Place::class, $place);
+        $this->assertSame('Place', $place->getType());
+    }
+
+    public function testVirtualLocationFactory(): void
+    {
+        $location = Schema::virtualLocation();
+        $this->assertInstanceOf(VirtualLocation::class, $location);
+        $this->assertSame('VirtualLocation', $location->getType());
+    }
+
+    public function testOfferFactory(): void
+    {
+        $offer = Schema::offer();
+        $this->assertInstanceOf(Offer::class, $offer);
+        $this->assertSame('Offer', $offer->getType());
+    }
+
+    public function testEventRendersValidJsonLd(): void
+    {
+        $manager = new Schema\SchemaManager();
+        $manager->add(
+            Schema::event()
+                ->name('Test Event')
+                ->startDate('2026-06-15')
+        );
+
+        $output = $manager->render();
+
+        $this->assertStringContainsString('"@type": "Event"', $output);
+        $this->assertStringContainsString('"name": "Test Event"', $output);
+    }
+}

--- a/src/Seo/Tests/SchemaFAQTest.php
+++ b/src/Seo/Tests/SchemaFAQTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaManager;
+use BackTo\Framework\Seo\Schema\Type\Answer;
+use BackTo\Framework\Seo\Schema\Type\FAQPage;
+use BackTo\Framework\Seo\Schema\Type\Question;
+use PHPUnit\Framework\TestCase;
+
+class SchemaFAQTest extends TestCase
+{
+    public function testFAQPageFactory(): void
+    {
+        $faq = Schema::faqPage();
+        $this->assertInstanceOf(FAQPage::class, $faq);
+        $this->assertSame('FAQPage', $faq->getType());
+    }
+
+    public function testQuestionFactory(): void
+    {
+        $question = Schema::question();
+        $this->assertInstanceOf(Question::class, $question);
+        $this->assertSame('Question', $question->getType());
+    }
+
+    public function testAnswerFactory(): void
+    {
+        $answer = Schema::answer();
+        $this->assertInstanceOf(Answer::class, $answer);
+        $this->assertSame('Answer', $answer->getType());
+    }
+
+    public function testAnswerText(): void
+    {
+        $array = Schema::answer()->text('Voici la réponse.')->toArray();
+        $this->assertSame('Voici la réponse.', $array['text']);
+    }
+
+    public function testQuestionName(): void
+    {
+        $array = Schema::question()->name('Comment ça marche ?')->toArray();
+        $this->assertSame('Comment ça marche ?', $array['name']);
+    }
+
+    public function testQuestionAcceptedAnswer(): void
+    {
+        $array = Schema::question()
+            ->acceptedAnswer(Schema::answer()->text('Comme ceci.'))
+            ->toArray();
+
+        $this->assertSame('Answer', $array['acceptedAnswer']['@type']);
+        $this->assertSame('Comme ceci.', $array['acceptedAnswer']['text']);
+    }
+
+    public function testQuestionSuggestedAnswer(): void
+    {
+        $array = Schema::question()
+            ->suggestedAnswer([
+                Schema::answer()->text('Option A'),
+                Schema::answer()->text('Option B'),
+            ])
+            ->toArray();
+
+        $this->assertCount(2, $array['suggestedAnswer']);
+        $this->assertSame('Answer', $array['suggestedAnswer'][0]['@type']);
+        $this->assertSame('Option A', $array['suggestedAnswer'][0]['text']);
+        $this->assertSame('Option B', $array['suggestedAnswer'][1]['text']);
+    }
+
+    public function testFAQPageMainEntity(): void
+    {
+        $array = Schema::faqPage()
+            ->mainEntity([
+                Schema::question()->name('Q1')->acceptedAnswer(Schema::answer()->text('R1')),
+                Schema::question()->name('Q2')->acceptedAnswer(Schema::answer()->text('R2')),
+            ])
+            ->toArray();
+
+        $this->assertSame('FAQPage', $array['@type']);
+        $this->assertCount(2, $array['mainEntity']);
+        $this->assertSame('Question', $array['mainEntity'][0]['@type']);
+        $this->assertSame('Q1', $array['mainEntity'][0]['name']);
+        $this->assertSame('Answer', $array['mainEntity'][0]['acceptedAnswer']['@type']);
+        $this->assertSame('R1', $array['mainEntity'][0]['acceptedAnswer']['text']);
+    }
+
+    public function testFullFAQComposition(): void
+    {
+        $faq = Schema::faqPage()->mainEntity([
+            Schema::question()
+                ->name('Quels sont vos horaires ?')
+                ->acceptedAnswer(Schema::answer()->text('Nous sommes ouverts du lundi au vendredi de 9h à 18h.')),
+            Schema::question()
+                ->name('Livrez-vous à l\'international ?')
+                ->acceptedAnswer(Schema::answer()->text('Oui, nous livrons dans toute l\'Europe.')),
+            Schema::question()
+                ->name('Comment retourner un produit ?')
+                ->acceptedAnswer(Schema::answer()->text('Vous avez 30 jours pour retourner un produit. Contactez notre service client.')),
+        ]);
+
+        $array = $faq->toArray();
+
+        $this->assertSame('FAQPage', $array['@type']);
+        $this->assertCount(3, $array['mainEntity']);
+
+        // Verify each Q&A pair
+        $this->assertSame('Quels sont vos horaires ?', $array['mainEntity'][0]['name']);
+        $this->assertStringContainsString('lundi au vendredi', $array['mainEntity'][0]['acceptedAnswer']['text']);
+
+        $this->assertSame('Livrez-vous à l\'international ?', $array['mainEntity'][1]['name']);
+        $this->assertStringContainsString('Europe', $array['mainEntity'][1]['acceptedAnswer']['text']);
+
+        $this->assertSame('Comment retourner un produit ?', $array['mainEntity'][2]['name']);
+        $this->assertStringContainsString('30 jours', $array['mainEntity'][2]['acceptedAnswer']['text']);
+    }
+
+    public function testFAQRendersValidJsonLd(): void
+    {
+        $manager = new SchemaManager();
+        $manager->add(
+            Schema::faqPage()->mainEntity([
+                Schema::question()->name('Q?')->acceptedAnswer(Schema::answer()->text('A.')),
+            ])
+        );
+
+        $output = $manager->render();
+
+        preg_match('/<script type="application\/ld\+json">\n(.+)\n<\/script>/s', $output, $matches);
+        $decoded = json_decode($matches[1], true);
+
+        $this->assertSame('https://schema.org', $decoded['@context']);
+        $this->assertSame('FAQPage', $decoded['@type']);
+        $this->assertCount(1, $decoded['mainEntity']);
+        $this->assertSame('Question', $decoded['mainEntity'][0]['@type']);
+        $this->assertSame('Q?', $decoded['mainEntity'][0]['name']);
+        $this->assertSame('Answer', $decoded['mainEntity'][0]['acceptedAnswer']['@type']);
+        $this->assertSame('A.', $decoded['mainEntity'][0]['acceptedAnswer']['text']);
+    }
+}

--- a/src/Seo/Tests/SchemaFactoryTest.php
+++ b/src/Seo/Tests/SchemaFactoryTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaType;
+use BackTo\Framework\Seo\Schema\Type\Article;
+use BackTo\Framework\Seo\Schema\Type\BreadcrumbList;
+use BackTo\Framework\Seo\Schema\Type\ImageObject;
+use BackTo\Framework\Seo\Schema\Type\ListItem;
+use BackTo\Framework\Seo\Schema\Type\LocalBusiness;
+use BackTo\Framework\Seo\Schema\Type\Organization;
+use BackTo\Framework\Seo\Schema\Type\Person;
+use BackTo\Framework\Seo\Schema\Type\PostalAddress;
+use BackTo\Framework\Seo\Schema\Type\SearchAction;
+use BackTo\Framework\Seo\Schema\Type\WebSite;
+use PHPUnit\Framework\TestCase;
+
+class SchemaFactoryTest extends TestCase
+{
+    public function testOrganization(): void
+    {
+        $schema = Schema::organization();
+        $this->assertInstanceOf(Organization::class, $schema);
+        $this->assertSame('Organization', $schema->getType());
+    }
+
+    public function testLocalBusiness(): void
+    {
+        $schema = Schema::localBusiness();
+        $this->assertInstanceOf(LocalBusiness::class, $schema);
+        $this->assertSame('LocalBusiness', $schema->getType());
+    }
+
+    public function testArticle(): void
+    {
+        $schema = Schema::article();
+        $this->assertInstanceOf(Article::class, $schema);
+        $this->assertSame('Article', $schema->getType());
+    }
+
+    public function testBreadcrumbList(): void
+    {
+        $schema = Schema::breadcrumbList();
+        $this->assertInstanceOf(BreadcrumbList::class, $schema);
+        $this->assertSame('BreadcrumbList', $schema->getType());
+    }
+
+    public function testListItem(): void
+    {
+        $schema = Schema::listItem();
+        $this->assertInstanceOf(ListItem::class, $schema);
+        $this->assertSame('ListItem', $schema->getType());
+    }
+
+    public function testPerson(): void
+    {
+        $schema = Schema::person();
+        $this->assertInstanceOf(Person::class, $schema);
+        $this->assertSame('Person', $schema->getType());
+    }
+
+    public function testPostalAddress(): void
+    {
+        $schema = Schema::postalAddress();
+        $this->assertInstanceOf(PostalAddress::class, $schema);
+        $this->assertSame('PostalAddress', $schema->getType());
+    }
+
+    public function testWebSite(): void
+    {
+        $schema = Schema::webSite();
+        $this->assertInstanceOf(WebSite::class, $schema);
+        $this->assertSame('WebSite', $schema->getType());
+    }
+
+    public function testImageObject(): void
+    {
+        $schema = Schema::imageObject();
+        $this->assertInstanceOf(ImageObject::class, $schema);
+        $this->assertSame('ImageObject', $schema->getType());
+    }
+
+    public function testSearchAction(): void
+    {
+        $schema = Schema::searchAction();
+        $this->assertInstanceOf(SearchAction::class, $schema);
+        $this->assertSame('SearchAction', $schema->getType());
+    }
+
+    public function testGenericType(): void
+    {
+        $schema = Schema::type('Product');
+        $this->assertInstanceOf(SchemaType::class, $schema);
+        $this->assertSame('Product', $schema->getType());
+    }
+
+    public function testFluentComposition(): void
+    {
+        $schema = Schema::organization()
+            ->name('Acme Corp')
+            ->url('https://acme.com')
+            ->logo('https://acme.com/logo.png')
+            ->address(
+                Schema::postalAddress()
+                    ->streetAddress('123 Main St')
+                    ->addressLocality('Paris')
+                    ->postalCode('75001')
+                    ->addressCountry('FR')
+            )
+            ->sameAs(['https://facebook.com/acme', 'https://twitter.com/acme']);
+
+        $array = $schema->toArray();
+
+        $this->assertSame('Organization', $array['@type']);
+        $this->assertSame('Acme Corp', $array['name']);
+        $this->assertSame('PostalAddress', $array['address']['@type']);
+        $this->assertSame('Paris', $array['address']['addressLocality']);
+        $this->assertCount(2, $array['sameAs']);
+    }
+
+    public function testBreadcrumbComposition(): void
+    {
+        $schema = Schema::breadcrumbList()->items([
+            Schema::listItem()->position(1)->name('Accueil')->url('/'),
+            Schema::listItem()->position(2)->name('Blog')->url('/blog'),
+            Schema::listItem()->position(3)->name('Article')->url('/blog/article'),
+        ]);
+
+        $array = $schema->toArray();
+
+        $this->assertSame('BreadcrumbList', $array['@type']);
+        $this->assertCount(3, $array['itemListElement']);
+        $this->assertSame(2, $array['itemListElement'][1]['position']);
+        $this->assertSame('/blog', $array['itemListElement'][1]['item']);
+    }
+
+    public function testArticleWithNestedTypes(): void
+    {
+        $schema = Schema::article()
+            ->headline('Mon article')
+            ->author(Schema::person()->name('Jean Dupont'))
+            ->publisher(
+                Schema::organization()
+                    ->name('Acme')
+                    ->logo(Schema::imageObject()->url('https://acme.com/logo.png')->width(600)->height(60))
+            )
+            ->datePublished('2026-03-16')
+            ->dateModified('2026-03-16');
+
+        $array = $schema->toArray();
+
+        $this->assertSame('Article', $array['@type']);
+        $this->assertSame('Person', $array['author']['@type']);
+        $this->assertSame('Jean Dupont', $array['author']['name']);
+        $this->assertSame('Organization', $array['publisher']['@type']);
+        $this->assertSame('ImageObject', $array['publisher']['logo']['@type']);
+    }
+}

--- a/src/Seo/Tests/SchemaJobPostingTest.php
+++ b/src/Seo/Tests/SchemaJobPostingTest.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaManager;
+use BackTo\Framework\Seo\Schema\Type\JobPosting;
+use PHPUnit\Framework\TestCase;
+
+class SchemaJobPostingTest extends TestCase
+{
+    public function testJobPostingFactory(): void
+    {
+        $job = Schema::jobPosting();
+        $this->assertInstanceOf(JobPosting::class, $job);
+        $this->assertSame('JobPosting', $job->getType());
+    }
+
+    public function testJobTitle(): void
+    {
+        $array = Schema::jobPosting()->title('Développeur PHP Senior')->toArray();
+        $this->assertSame('Développeur PHP Senior', $array['title']);
+    }
+
+    public function testJobDescription(): void
+    {
+        $array = Schema::jobPosting()->description('Rejoignez notre équipe technique.')->toArray();
+        $this->assertSame('Rejoignez notre équipe technique.', $array['description']);
+    }
+
+    public function testJobDatePosted(): void
+    {
+        $array = Schema::jobPosting()->datePosted('2026-03-15')->toArray();
+        $this->assertSame('2026-03-15', $array['datePosted']);
+    }
+
+    public function testJobValidThrough(): void
+    {
+        $array = Schema::jobPosting()->validThrough('2026-06-15')->toArray();
+        $this->assertSame('2026-06-15', $array['validThrough']);
+    }
+
+    public function testJobHiringOrganization(): void
+    {
+        $array = Schema::jobPosting()
+            ->hiringOrganization(Schema::organization()->name('Acme Corp')->url('https://acme.com'))
+            ->toArray();
+
+        $this->assertSame('Organization', $array['hiringOrganization']['@type']);
+        $this->assertSame('Acme Corp', $array['hiringOrganization']['name']);
+    }
+
+    public function testJobLocation(): void
+    {
+        $array = Schema::jobPosting()
+            ->jobLocation(
+                Schema::place()->address(
+                    Schema::postalAddress()
+                        ->addressLocality('Lyon')
+                        ->addressRegion('Auvergne-Rhône-Alpes')
+                        ->addressCountry('FR')
+                )
+            )
+            ->toArray();
+
+        $this->assertSame('Place', $array['jobLocation']['@type']);
+        $this->assertSame('PostalAddress', $array['jobLocation']['address']['@type']);
+        $this->assertSame('Lyon', $array['jobLocation']['address']['addressLocality']);
+    }
+
+    public function testJobBaseSalary(): void
+    {
+        $array = Schema::jobPosting()
+            ->baseSalary(
+                Schema::monetaryAmount()
+                    ->currency('EUR')
+                    ->value(
+                        Schema::type('QuantitativeValue')
+                            ->set('value', 55000)
+                            ->set('unitText', 'YEAR')
+                    )
+            )
+            ->toArray();
+
+        $this->assertSame('MonetaryAmount', $array['baseSalary']['@type']);
+        $this->assertSame('EUR', $array['baseSalary']['currency']);
+        $this->assertSame('QuantitativeValue', $array['baseSalary']['value']['@type']);
+        $this->assertSame(55000, $array['baseSalary']['value']['value']);
+    }
+
+    public function testJobBaseSalaryRange(): void
+    {
+        $array = Schema::jobPosting()
+            ->baseSalary(
+                Schema::monetaryAmount()
+                    ->currency('EUR')
+                    ->minValue(45000)
+                    ->maxValue(65000)
+            )
+            ->toArray();
+
+        $this->assertSame(45000, $array['baseSalary']['minValue']);
+        $this->assertSame(65000, $array['baseSalary']['maxValue']);
+    }
+
+    public function testJobEmploymentTypeString(): void
+    {
+        $array = Schema::jobPosting()->employmentType('FULL_TIME')->toArray();
+        $this->assertSame('FULL_TIME', $array['employmentType']);
+    }
+
+    public function testJobEmploymentTypeArray(): void
+    {
+        $array = Schema::jobPosting()->employmentType(['FULL_TIME', 'CONTRACTOR'])->toArray();
+        $this->assertSame(['FULL_TIME', 'CONTRACTOR'], $array['employmentType']);
+    }
+
+    public function testJobLocationType(): void
+    {
+        $array = Schema::jobPosting()->jobLocationType('TELECOMMUTE')->toArray();
+        $this->assertSame('TELECOMMUTE', $array['jobLocationType']);
+    }
+
+    public function testJobUrl(): void
+    {
+        $array = Schema::jobPosting()->url('https://acme.com/jobs/dev-php')->toArray();
+        $this->assertSame('https://acme.com/jobs/dev-php', $array['url']);
+    }
+
+    public function testJobDirectApply(): void
+    {
+        $array = Schema::jobPosting()->directApply(true)->toArray();
+        $this->assertTrue($array['directApply']);
+    }
+
+    public function testJobIdentifierString(): void
+    {
+        $array = Schema::jobPosting()->identifier('JOB-2026-001')->toArray();
+        $this->assertSame('JOB-2026-001', $array['identifier']);
+    }
+
+    public function testJobIndustry(): void
+    {
+        $array = Schema::jobPosting()->industry('Informatique')->toArray();
+        $this->assertSame('Informatique', $array['industry']);
+    }
+
+    public function testJobQualifications(): void
+    {
+        $array = Schema::jobPosting()->qualifications('5 ans d\'expérience PHP')->toArray();
+        $this->assertSame('5 ans d\'expérience PHP', $array['qualifications']);
+    }
+
+    public function testJobResponsibilities(): void
+    {
+        $array = Schema::jobPosting()->responsibilities('Développer et maintenir l\'API')->toArray();
+        $this->assertSame('Développer et maintenir l\'API', $array['responsibilities']);
+    }
+
+    public function testJobSkills(): void
+    {
+        $array = Schema::jobPosting()->skills('PHP, Symfony, Docker')->toArray();
+        $this->assertSame('PHP, Symfony, Docker', $array['skills']);
+    }
+
+    public function testJobExperienceRequirements(): void
+    {
+        $array = Schema::jobPosting()->experienceRequirements('5 ans minimum')->toArray();
+        $this->assertSame('5 ans minimum', $array['experienceRequirements']);
+    }
+
+    public function testJobEducationRequirements(): void
+    {
+        $array = Schema::jobPosting()->educationRequirements('Bac+5 en informatique')->toArray();
+        $this->assertSame('Bac+5 en informatique', $array['educationRequirements']);
+    }
+
+    public function testJobApplicantLocationRequirements(): void
+    {
+        $array = Schema::jobPosting()
+            ->applicantLocationRequirements(
+                Schema::type('Country')->set('name', 'France')
+            )
+            ->toArray();
+
+        $this->assertSame('Country', $array['applicantLocationRequirements']['@type']);
+        $this->assertSame('France', $array['applicantLocationRequirements']['name']);
+    }
+
+    public function testFullJobPostingComposition(): void
+    {
+        $job = Schema::jobPosting()
+            ->title('Développeur WordPress Senior')
+            ->description('Rejoignez notre équipe pour développer des thèmes et plugins WordPress.')
+            ->datePosted('2026-03-15')
+            ->validThrough('2026-06-15')
+            ->hiringOrganization(
+                Schema::organization()
+                    ->name('Agence Web Acme')
+                    ->url('https://acme-web.fr')
+                    ->logo('https://acme-web.fr/logo.png')
+            )
+            ->jobLocation(
+                Schema::place()->address(
+                    Schema::postalAddress()
+                        ->streetAddress('10 rue de la Paix')
+                        ->addressLocality('Lyon')
+                        ->postalCode('69002')
+                        ->addressCountry('FR')
+                )
+            )
+            ->baseSalary(
+                Schema::monetaryAmount()
+                    ->currency('EUR')
+                    ->minValue(45000)
+                    ->maxValue(60000)
+            )
+            ->employmentType('FULL_TIME')
+            ->industry('Développement Web')
+            ->skills('PHP, WordPress, JavaScript, Docker')
+            ->qualifications('5 ans d\'expérience en développement WordPress')
+            ->directApply(true)
+            ->url('https://acme-web.fr/jobs/dev-wp-senior');
+
+        $array = $job->toArray();
+
+        $this->assertSame('JobPosting', $array['@type']);
+        $this->assertSame('Développeur WordPress Senior', $array['title']);
+        $this->assertSame('2026-03-15', $array['datePosted']);
+        $this->assertSame('2026-06-15', $array['validThrough']);
+        $this->assertSame('Organization', $array['hiringOrganization']['@type']);
+        $this->assertSame('Agence Web Acme', $array['hiringOrganization']['name']);
+        $this->assertSame('Place', $array['jobLocation']['@type']);
+        $this->assertSame('Lyon', $array['jobLocation']['address']['addressLocality']);
+        $this->assertSame('MonetaryAmount', $array['baseSalary']['@type']);
+        $this->assertSame(45000, $array['baseSalary']['minValue']);
+        $this->assertSame(60000, $array['baseSalary']['maxValue']);
+        $this->assertSame('FULL_TIME', $array['employmentType']);
+        $this->assertTrue($array['directApply']);
+    }
+
+    public function testRemoteJobPosting(): void
+    {
+        $job = Schema::jobPosting()
+            ->title('Développeur Remote')
+            ->jobLocationType('TELECOMMUTE')
+            ->applicantLocationRequirements(
+                Schema::type('Country')->set('name', 'France')
+            )
+            ->hiringOrganization(Schema::organization()->name('Remote Corp'));
+
+        $array = $job->toArray();
+
+        $this->assertSame('TELECOMMUTE', $array['jobLocationType']);
+        $this->assertSame('Country', $array['applicantLocationRequirements']['@type']);
+    }
+
+    public function testJobPostingRendersValidJsonLd(): void
+    {
+        $manager = new SchemaManager();
+        $manager->add(
+            Schema::jobPosting()
+                ->title('Dev PHP')
+                ->hiringOrganization(Schema::organization()->name('Acme'))
+                ->datePosted('2026-03-15')
+        );
+
+        $output = $manager->render();
+
+        preg_match('/<script type="application\/ld\+json">\n(.+)\n<\/script>/s', $output, $matches);
+        $decoded = json_decode($matches[1], true);
+
+        $this->assertSame('https://schema.org', $decoded['@context']);
+        $this->assertSame('JobPosting', $decoded['@type']);
+        $this->assertSame('Dev PHP', $decoded['title']);
+        $this->assertSame('Organization', $decoded['hiringOrganization']['@type']);
+    }
+}

--- a/src/Seo/Tests/SchemaManagerTest.php
+++ b/src/Seo/Tests/SchemaManagerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema\SchemaManager;
+use BackTo\Framework\Seo\Schema\SchemaType;
+use PHPUnit\Framework\TestCase;
+
+class SchemaManagerTest extends TestCase
+{
+    public function testEmptyByDefault(): void
+    {
+        $manager = new SchemaManager();
+
+        $this->assertFalse($manager->hasSchemas());
+        $this->assertSame([], $manager->getSchemas());
+        $this->assertSame([], $manager->toArray());
+    }
+
+    public function testRenderReturnsEmptyStringWhenNoSchemas(): void
+    {
+        $manager = new SchemaManager();
+        $this->assertSame('', $manager->render());
+    }
+
+    public function testAddSchema(): void
+    {
+        $manager = new SchemaManager();
+        $schema = new SchemaType('Organization');
+
+        $result = $manager->add($schema);
+
+        $this->assertSame($manager, $result, 'add() should return $this');
+        $this->assertTrue($manager->hasSchemas());
+        $this->assertCount(1, $manager->getSchemas());
+    }
+
+    public function testToArray(): void
+    {
+        $manager = new SchemaManager();
+        $manager->add((new SchemaType('Organization'))->set('name', 'Acme'));
+        $manager->add((new SchemaType('WebSite'))->set('name', 'My Site'));
+
+        $array = $manager->toArray();
+
+        $this->assertCount(2, $array);
+        $this->assertSame('Organization', $array[0]['@type']);
+        $this->assertSame('WebSite', $array[1]['@type']);
+    }
+
+    public function testRenderSingleSchemaWithoutGraph(): void
+    {
+        $manager = new SchemaManager();
+        $manager->add((new SchemaType('Organization'))->set('name', 'Acme'));
+
+        $output = $manager->render();
+
+        $this->assertStringContainsString('<script type="application/ld+json">', $output);
+        $this->assertStringContainsString('</script>', $output);
+        $this->assertStringContainsString('"@context": "https://schema.org"', $output);
+        $this->assertStringContainsString('"@type": "Organization"', $output);
+        $this->assertStringNotContainsString('@graph', $output);
+    }
+
+    public function testRenderMultipleSchemasUsesGraph(): void
+    {
+        $manager = new SchemaManager();
+        $manager->add((new SchemaType('Organization'))->set('name', 'Acme'));
+        $manager->add((new SchemaType('WebSite'))->set('name', 'My Site'));
+
+        $output = $manager->render();
+
+        $this->assertStringContainsString('@graph', $output);
+
+        // Verify the JSON is valid
+        preg_match('/<script type="application\/ld\+json">\n(.+)\n<\/script>/s', $output, $matches);
+        $this->assertNotEmpty($matches);
+
+        $decoded = json_decode($matches[1], true);
+        $this->assertSame('https://schema.org', $decoded['@context']);
+        $this->assertCount(2, $decoded['@graph']);
+    }
+
+    public function testRenderProducesValidJson(): void
+    {
+        $manager = new SchemaManager();
+        $manager->add(
+            (new SchemaType('Organization'))
+                ->set('name', 'Acme Corp')
+                ->set('url', 'https://acme.com/path?q=1&b=2')
+        );
+
+        $output = $manager->render();
+
+        preg_match('/<script type="application\/ld\+json">\n(.+)\n<\/script>/s', $output, $matches);
+        $decoded = json_decode($matches[1], true);
+
+        $this->assertNotNull($decoded);
+        $this->assertSame('https://acme.com/path?q=1&b=2', $decoded['url']);
+    }
+}

--- a/src/Seo/Tests/SchemaProductTest.php
+++ b/src/Seo/Tests/SchemaProductTest.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaManager;
+use BackTo\Framework\Seo\Schema\Type\Brand;
+use BackTo\Framework\Seo\Schema\Type\MerchantReturnPolicy;
+use BackTo\Framework\Seo\Schema\Type\MonetaryAmount;
+use BackTo\Framework\Seo\Schema\Type\OfferShippingDetails;
+use BackTo\Framework\Seo\Schema\Type\Product;
+use PHPUnit\Framework\TestCase;
+
+class SchemaProductTest extends TestCase
+{
+    public function testProductFactory(): void
+    {
+        $product = Schema::product();
+        $this->assertInstanceOf(Product::class, $product);
+        $this->assertSame('Product', $product->getType());
+    }
+
+    public function testBrandFactory(): void
+    {
+        $brand = Schema::brand();
+        $this->assertInstanceOf(Brand::class, $brand);
+        $this->assertSame('Brand', $brand->getType());
+    }
+
+    public function testOfferShippingDetailsFactory(): void
+    {
+        $details = Schema::offerShippingDetails();
+        $this->assertInstanceOf(OfferShippingDetails::class, $details);
+        $this->assertSame('OfferShippingDetails', $details->getType());
+    }
+
+    public function testMerchantReturnPolicyFactory(): void
+    {
+        $policy = Schema::merchantReturnPolicy();
+        $this->assertInstanceOf(MerchantReturnPolicy::class, $policy);
+        $this->assertSame('MerchantReturnPolicy', $policy->getType());
+    }
+
+    public function testMonetaryAmountFactory(): void
+    {
+        $amount = Schema::monetaryAmount();
+        $this->assertInstanceOf(MonetaryAmount::class, $amount);
+        $this->assertSame('MonetaryAmount', $amount->getType());
+    }
+
+    public function testProductName(): void
+    {
+        $array = Schema::product()->name('Widget Pro')->toArray();
+        $this->assertSame('Widget Pro', $array['name']);
+    }
+
+    public function testProductDescription(): void
+    {
+        $array = Schema::product()->description('Un widget performant')->toArray();
+        $this->assertSame('Un widget performant', $array['description']);
+    }
+
+    public function testProductImage(): void
+    {
+        $array = Schema::product()->image('https://example.com/img.jpg')->toArray();
+        $this->assertSame('https://example.com/img.jpg', $array['image']);
+    }
+
+    public function testProductImageArray(): void
+    {
+        $images = ['https://example.com/1.jpg', 'https://example.com/2.jpg'];
+        $array = Schema::product()->image($images)->toArray();
+        $this->assertSame($images, $array['image']);
+    }
+
+    public function testProductUrl(): void
+    {
+        $array = Schema::product()->url('https://example.com/product')->toArray();
+        $this->assertSame('https://example.com/product', $array['url']);
+    }
+
+    public function testProductSku(): void
+    {
+        $array = Schema::product()->sku('WDG-001')->toArray();
+        $this->assertSame('WDG-001', $array['sku']);
+    }
+
+    public function testProductGtin(): void
+    {
+        $array = Schema::product()->gtin('0123456789012')->toArray();
+        $this->assertSame('0123456789012', $array['gtin']);
+    }
+
+    public function testProductGtin13(): void
+    {
+        $array = Schema::product()->gtin13('0123456789012')->toArray();
+        $this->assertSame('0123456789012', $array['gtin13']);
+    }
+
+    public function testProductMpn(): void
+    {
+        $array = Schema::product()->mpn('MPN-123')->toArray();
+        $this->assertSame('MPN-123', $array['mpn']);
+    }
+
+    public function testProductColor(): void
+    {
+        $array = Schema::product()->color('Rouge')->toArray();
+        $this->assertSame('Rouge', $array['color']);
+    }
+
+    public function testProductSize(): void
+    {
+        $array = Schema::product()->size('XL')->toArray();
+        $this->assertSame('XL', $array['size']);
+    }
+
+    public function testProductMaterial(): void
+    {
+        $array = Schema::product()->material('Coton bio')->toArray();
+        $this->assertSame('Coton bio', $array['material']);
+    }
+
+    public function testProductCategory(): void
+    {
+        $array = Schema::product()->category('Vêtements')->toArray();
+        $this->assertSame('Vêtements', $array['category']);
+    }
+
+    public function testProductBrand(): void
+    {
+        $array = Schema::product()
+            ->brand(Schema::brand()->name('Acme'))
+            ->toArray();
+
+        $this->assertSame('Brand', $array['brand']['@type']);
+        $this->assertSame('Acme', $array['brand']['name']);
+    }
+
+    public function testBrandProperties(): void
+    {
+        $array = Schema::brand()
+            ->name('Acme')
+            ->url('https://acme.com')
+            ->logo('https://acme.com/logo.png')
+            ->toArray();
+
+        $this->assertSame('Acme', $array['name']);
+        $this->assertSame('https://acme.com', $array['url']);
+        $this->assertSame('https://acme.com/logo.png', $array['logo']);
+    }
+
+    public function testProductSingleOffer(): void
+    {
+        $array = Schema::product()
+            ->offers(Schema::offer()->price('29.99')->priceCurrency('EUR'))
+            ->toArray();
+
+        $this->assertSame('Offer', $array['offers']['@type']);
+        $this->assertSame('29.99', $array['offers']['price']);
+        $this->assertSame('EUR', $array['offers']['priceCurrency']);
+    }
+
+    public function testProductMultipleOffers(): void
+    {
+        $array = Schema::product()
+            ->offers([
+                Schema::offer()->price('29.99')->priceCurrency('EUR'),
+                Schema::offer()->price('39.99')->priceCurrency('EUR'),
+            ])
+            ->toArray();
+
+        $this->assertCount(2, $array['offers']);
+        $this->assertSame('29.99', $array['offers'][0]['price']);
+        $this->assertSame('39.99', $array['offers'][1]['price']);
+    }
+
+    public function testProductAggregateRating(): void
+    {
+        $array = Schema::product()
+            ->aggregateRating(Schema::aggregateRating()->ratingValue(4.5)->reviewCount(120))
+            ->toArray();
+
+        $this->assertSame('AggregateRating', $array['aggregateRating']['@type']);
+        $this->assertSame(4.5, $array['aggregateRating']['ratingValue']);
+        $this->assertSame(120, $array['aggregateRating']['reviewCount']);
+    }
+
+    public function testProductReview(): void
+    {
+        $array = Schema::product()
+            ->review(Schema::review()->author(Schema::person()->name('Jean'))->reviewBody('Super produit'))
+            ->toArray();
+
+        $this->assertSame('Review', $array['review']['@type']);
+        $this->assertSame('Super produit', $array['review']['reviewBody']);
+    }
+
+    public function testOfferShippingDetailsProperties(): void
+    {
+        $array = Schema::offerShippingDetails()
+            ->shippingRate(Schema::monetaryAmount()->currency('EUR')->value(5.99))
+            ->shippingDestination(Schema::type('DefinedRegion')->set('addressCountry', 'FR'))
+            ->deliveryTime(Schema::type('ShippingDeliveryTime')->set('handlingTime', Schema::type('QuantitativeValue')->set('minValue', 0)->set('maxValue', 1)))
+            ->toArray();
+
+        $this->assertSame('OfferShippingDetails', $array['@type']);
+        $this->assertSame('MonetaryAmount', $array['shippingRate']['@type']);
+        $this->assertSame('EUR', $array['shippingRate']['currency']);
+        $this->assertSame(5.99, $array['shippingRate']['value']);
+    }
+
+    public function testMerchantReturnPolicyProperties(): void
+    {
+        $array = Schema::merchantReturnPolicy()
+            ->applicableCountry('FR')
+            ->returnPolicyCategory('https://schema.org/MerchantReturnFiniteReturnWindow')
+            ->merchantReturnDays(30)
+            ->returnMethod('https://schema.org/ReturnByMail')
+            ->returnFees('https://schema.org/FreeReturn')
+            ->toArray();
+
+        $this->assertSame('MerchantReturnPolicy', $array['@type']);
+        $this->assertSame('FR', $array['applicableCountry']);
+        $this->assertSame(30, $array['merchantReturnDays']);
+        $this->assertSame('https://schema.org/FreeReturn', $array['returnFees']);
+    }
+
+    public function testMonetaryAmountProperties(): void
+    {
+        $array = Schema::monetaryAmount()
+            ->currency('EUR')
+            ->value(1500)
+            ->minValue(1200)
+            ->maxValue(1800)
+            ->toArray();
+
+        $this->assertSame('MonetaryAmount', $array['@type']);
+        $this->assertSame('EUR', $array['currency']);
+        $this->assertSame(1500, $array['value']);
+        $this->assertSame(1200, $array['minValue']);
+        $this->assertSame(1800, $array['maxValue']);
+    }
+
+    public function testFullProductComposition(): void
+    {
+        $product = Schema::product()
+            ->name('T-Shirt Acme')
+            ->description('T-shirt 100% coton bio')
+            ->image(['https://example.com/front.jpg', 'https://example.com/back.jpg'])
+            ->url('https://example.com/t-shirt-acme')
+            ->sku('TSH-001')
+            ->gtin13('3760000000001')
+            ->brand(Schema::brand()->name('Acme'))
+            ->color('Bleu')
+            ->size('M')
+            ->material('Coton bio')
+            ->category('Vêtements')
+            ->offers(
+                Schema::offer()
+                    ->price('29.99')
+                    ->priceCurrency('EUR')
+                    ->availability('https://schema.org/InStock')
+                    ->url('https://example.com/t-shirt-acme')
+            )
+            ->aggregateRating(
+                Schema::aggregateRating()->ratingValue(4.8)->reviewCount(256)->ratingCount(300)
+            )
+            ->review([
+                Schema::review()
+                    ->author(Schema::person()->name('Marie'))
+                    ->reviewRating(Schema::rating()->ratingValue(5)->bestRating(5))
+                    ->reviewBody('Excellent produit !')
+                    ->datePublished('2026-03-10'),
+            ]);
+
+        $array = $product->toArray();
+
+        $this->assertSame('Product', $array['@type']);
+        $this->assertSame('T-Shirt Acme', $array['name']);
+        $this->assertSame('TSH-001', $array['sku']);
+        $this->assertSame('Brand', $array['brand']['@type']);
+        $this->assertSame('Bleu', $array['color']);
+        $this->assertSame('Offer', $array['offers']['@type']);
+        $this->assertSame('29.99', $array['offers']['price']);
+        $this->assertSame(4.8, $array['aggregateRating']['ratingValue']);
+        $this->assertCount(1, $array['review']);
+        $this->assertSame('Review', $array['review'][0]['@type']);
+        $this->assertSame('Rating', $array['review'][0]['reviewRating']['@type']);
+    }
+
+    public function testProductRendersValidJsonLd(): void
+    {
+        $manager = new SchemaManager();
+        $manager->add(
+            Schema::product()
+                ->name('Widget')
+                ->offers(Schema::offer()->price('9.99')->priceCurrency('EUR'))
+        );
+
+        $output = $manager->render();
+
+        preg_match('/<script type="application\/ld\+json">\n(.+)\n<\/script>/s', $output, $matches);
+        $decoded = json_decode($matches[1], true);
+
+        $this->assertSame('https://schema.org', $decoded['@context']);
+        $this->assertSame('Product', $decoded['@type']);
+        $this->assertSame('Widget', $decoded['name']);
+        $this->assertSame('Offer', $decoded['offers']['@type']);
+    }
+}

--- a/src/Seo/Tests/SchemaRefTest.php
+++ b/src/Seo/Tests/SchemaRefTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaManager;
+use BackTo\Framework\Seo\Schema\SchemaRef;
+use BackTo\Framework\Seo\Schema\SchemaType;
+use PHPUnit\Framework\TestCase;
+
+class SchemaRefTest extends TestCase
+{
+    public function testRefFactory(): void
+    {
+        $ref = Schema::ref('#organization');
+        $this->assertInstanceOf(SchemaRef::class, $ref);
+    }
+
+    public function testRefGetId(): void
+    {
+        $ref = new SchemaRef('#organization');
+        $this->assertSame('#organization', $ref->getId());
+    }
+
+    public function testRefToArray(): void
+    {
+        $ref = new SchemaRef('https://example.com/#organization');
+        $this->assertSame(['@id' => 'https://example.com/#organization'], $ref->toArray());
+    }
+
+    public function testRefJsonSerializable(): void
+    {
+        $ref = new SchemaRef('#website');
+        $json = json_encode($ref);
+        $decoded = json_decode($json, true);
+
+        $this->assertSame(['@id' => '#website'], $decoded);
+    }
+
+    public function testSchemaTypeResolvesRef(): void
+    {
+        $article = new SchemaType('Article');
+        $article->set('publisher', Schema::ref('#organization'));
+
+        $array = $article->toArray();
+
+        $this->assertSame(['@id' => '#organization'], $array['publisher']);
+    }
+
+    public function testSchemaTypeResolvesRefInArray(): void
+    {
+        $schema = new SchemaType('WebPage');
+        $schema->set('isPartOf', [
+            Schema::ref('#website'),
+            Schema::ref('#organization'),
+        ]);
+
+        $array = $schema->toArray();
+
+        $this->assertSame(['@id' => '#website'], $array['isPartOf'][0]);
+        $this->assertSame(['@id' => '#organization'], $array['isPartOf'][1]);
+    }
+
+    public function testIdAndRefProduceLinkedGraph(): void
+    {
+        $manager = new SchemaManager();
+
+        $org = Schema::organization()
+            ->id('https://example.com/#organization')
+            ->name('Acme');
+
+        $website = Schema::webSite()
+            ->id('https://example.com/#website')
+            ->name('Acme Site')
+            ->set('publisher', Schema::ref('https://example.com/#organization'));
+
+        $article = Schema::article()
+            ->headline('Test')
+            ->author(Schema::person()->name('John'))
+            ->datePublished('2026-01-01')
+            ->set('isPartOf', Schema::ref('https://example.com/#website'))
+            ->set('publisher', Schema::ref('https://example.com/#organization'));
+
+        $manager->add($org);
+        $manager->add($website);
+        $manager->add($article);
+
+        $output = $manager->render();
+
+        // Parse JSON-LD
+        preg_match('/<script type="application\/ld\+json">\n(.+)\n<\/script>/s', $output, $matches);
+        $decoded = json_decode($matches[1], true);
+
+        // Should use @graph for multiple schemas
+        $this->assertSame('https://schema.org', $decoded['@context']);
+        $this->assertCount(3, $decoded['@graph']);
+
+        // Organization has @id
+        $this->assertSame('https://example.com/#organization', $decoded['@graph'][0]['@id']);
+        $this->assertSame('Organization', $decoded['@graph'][0]['@type']);
+
+        // WebSite references Organization
+        $this->assertSame('https://example.com/#website', $decoded['@graph'][1]['@id']);
+        $this->assertSame(['@id' => 'https://example.com/#organization'], $decoded['@graph'][1]['publisher']);
+
+        // Article references both
+        $this->assertSame(['@id' => 'https://example.com/#website'], $decoded['@graph'][2]['isPartOf']);
+        $this->assertSame(['@id' => 'https://example.com/#organization'], $decoded['@graph'][2]['publisher']);
+    }
+}

--- a/src/Seo/Tests/SchemaReviewTest.php
+++ b/src/Seo/Tests/SchemaReviewTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaManager;
+use BackTo\Framework\Seo\Schema\Type\Rating;
+use BackTo\Framework\Seo\Schema\Type\Review;
+use PHPUnit\Framework\TestCase;
+
+class SchemaReviewTest extends TestCase
+{
+    public function testReviewFactory(): void
+    {
+        $review = Schema::review();
+        $this->assertInstanceOf(Review::class, $review);
+        $this->assertSame('Review', $review->getType());
+    }
+
+    public function testRatingFactory(): void
+    {
+        $rating = Schema::rating();
+        $this->assertInstanceOf(Rating::class, $rating);
+        $this->assertSame('Rating', $rating->getType());
+    }
+
+    public function testReviewItemReviewed(): void
+    {
+        $array = Schema::review()
+            ->itemReviewed(Schema::product()->name('Widget'))
+            ->toArray();
+
+        $this->assertSame('Product', $array['itemReviewed']['@type']);
+        $this->assertSame('Widget', $array['itemReviewed']['name']);
+    }
+
+    public function testReviewRating(): void
+    {
+        $array = Schema::review()
+            ->reviewRating(Schema::rating()->ratingValue(4)->bestRating(5)->worstRating(1))
+            ->toArray();
+
+        $this->assertSame('Rating', $array['reviewRating']['@type']);
+        $this->assertSame(4.0, $array['reviewRating']['ratingValue']);
+        $this->assertSame(5.0, $array['reviewRating']['bestRating']);
+        $this->assertSame(1.0, $array['reviewRating']['worstRating']);
+    }
+
+    public function testReviewAuthorAsSchemaType(): void
+    {
+        $array = Schema::review()
+            ->author(Schema::person()->name('Jean Dupont'))
+            ->toArray();
+
+        $this->assertSame('Person', $array['author']['@type']);
+        $this->assertSame('Jean Dupont', $array['author']['name']);
+    }
+
+    public function testReviewAuthorAsString(): void
+    {
+        $array = Schema::review()->author('Jean Dupont')->toArray();
+        $this->assertSame('Jean Dupont', $array['author']);
+    }
+
+    public function testReviewDatePublished(): void
+    {
+        $array = Schema::review()->datePublished('2026-03-15')->toArray();
+        $this->assertSame('2026-03-15', $array['datePublished']);
+    }
+
+    public function testReviewBody(): void
+    {
+        $array = Schema::review()->reviewBody('Excellent service !')->toArray();
+        $this->assertSame('Excellent service !', $array['reviewBody']);
+    }
+
+    public function testReviewName(): void
+    {
+        $array = Schema::review()->name('Mon avis')->toArray();
+        $this->assertSame('Mon avis', $array['name']);
+    }
+
+    public function testReviewPublisher(): void
+    {
+        $array = Schema::review()
+            ->publisher(Schema::organization()->name('Le Monde'))
+            ->toArray();
+
+        $this->assertSame('Organization', $array['publisher']['@type']);
+        $this->assertSame('Le Monde', $array['publisher']['name']);
+    }
+
+    public function testRatingValue(): void
+    {
+        $array = Schema::rating()->ratingValue(4.5)->toArray();
+        $this->assertSame(4.5, $array['ratingValue']);
+    }
+
+    public function testRatingValueAsString(): void
+    {
+        $array = Schema::rating()->ratingValue('4.5')->toArray();
+        $this->assertSame('4.5', $array['ratingValue']);
+    }
+
+    public function testRatingBestRating(): void
+    {
+        $array = Schema::rating()->bestRating(5)->toArray();
+        $this->assertSame(5.0, $array['bestRating']);
+    }
+
+    public function testRatingWorstRating(): void
+    {
+        $array = Schema::rating()->worstRating(1)->toArray();
+        $this->assertSame(1.0, $array['worstRating']);
+    }
+
+    public function testFullReviewComposition(): void
+    {
+        $review = Schema::review()
+            ->name('Excellent restaurant')
+            ->itemReviewed(Schema::localBusiness()->name('Chez Paul'))
+            ->reviewRating(Schema::rating()->ratingValue(5)->bestRating(5))
+            ->author(Schema::person()->name('Marie Martin'))
+            ->datePublished('2026-03-01')
+            ->reviewBody('Cuisine raffinée et service impeccable.')
+            ->publisher(Schema::organization()->name('Guide Resto'));
+
+        $array = $review->toArray();
+
+        $this->assertSame('Review', $array['@type']);
+        $this->assertSame('Excellent restaurant', $array['name']);
+        $this->assertSame('LocalBusiness', $array['itemReviewed']['@type']);
+        $this->assertSame('Rating', $array['reviewRating']['@type']);
+        $this->assertSame(5.0, $array['reviewRating']['ratingValue']);
+        $this->assertSame('Person', $array['author']['@type']);
+        $this->assertSame('2026-03-01', $array['datePublished']);
+        $this->assertSame('Cuisine raffinée et service impeccable.', $array['reviewBody']);
+        $this->assertSame('Organization', $array['publisher']['@type']);
+    }
+
+    public function testReviewRendersValidJsonLd(): void
+    {
+        $manager = new SchemaManager();
+        $manager->add(
+            Schema::review()
+                ->itemReviewed(Schema::product()->name('Widget'))
+                ->reviewRating(Schema::rating()->ratingValue(4))
+                ->author(Schema::person()->name('Test'))
+        );
+
+        $output = $manager->render();
+
+        preg_match('/<script type="application\/ld\+json">\n(.+)\n<\/script>/s', $output, $matches);
+        $decoded = json_decode($matches[1], true);
+
+        $this->assertSame('https://schema.org', $decoded['@context']);
+        $this->assertSame('Review', $decoded['@type']);
+        $this->assertSame('Product', $decoded['itemReviewed']['@type']);
+    }
+}

--- a/src/Seo/Tests/SchemaTypeTest.php
+++ b/src/Seo/Tests/SchemaTypeTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema\SchemaType;
+use PHPUnit\Framework\TestCase;
+
+class SchemaTypeTest extends TestCase
+{
+    public function testGetType(): void
+    {
+        $schema = new SchemaType('Organization');
+        $this->assertSame('Organization', $schema->getType());
+    }
+
+    public function testSetAndGetProperties(): void
+    {
+        $schema = new SchemaType('Person');
+        $result = $schema->set('name', 'John Doe');
+
+        $this->assertSame($schema, $result, 'set() should return $this for fluent chaining');
+        $this->assertSame(['name' => 'John Doe'], $schema->getProperties());
+    }
+
+    public function testId(): void
+    {
+        $schema = new SchemaType('Organization');
+        $schema->id('#org');
+
+        $array = $schema->toArray();
+        $this->assertSame('#org', $array['@id']);
+    }
+
+    public function testToArrayIncludesType(): void
+    {
+        $schema = new SchemaType('WebSite');
+        $schema->set('name', 'My Site');
+
+        $expected = [
+            '@type' => 'WebSite',
+            'name' => 'My Site',
+        ];
+
+        $this->assertSame($expected, $schema->toArray());
+    }
+
+    public function testNestedSchemaTypeIsResolved(): void
+    {
+        $address = new SchemaType('PostalAddress');
+        $address->set('streetAddress', '123 Main St');
+
+        $org = new SchemaType('Organization');
+        $org->set('name', 'Acme');
+        $org->set('address', $address);
+
+        $array = $org->toArray();
+
+        $this->assertSame([
+            '@type' => 'Organization',
+            'name' => 'Acme',
+            'address' => [
+                '@type' => 'PostalAddress',
+                'streetAddress' => '123 Main St',
+            ],
+        ], $array);
+    }
+
+    public function testArrayOfSchemaTypesIsResolved(): void
+    {
+        $item1 = new SchemaType('ListItem');
+        $item1->set('position', 1)->set('name', 'Home');
+
+        $item2 = new SchemaType('ListItem');
+        $item2->set('position', 2)->set('name', 'Blog');
+
+        $breadcrumb = new SchemaType('BreadcrumbList');
+        $breadcrumb->set('itemListElement', [$item1, $item2]);
+
+        $array = $breadcrumb->toArray();
+
+        $this->assertCount(2, $array['itemListElement']);
+        $this->assertSame('ListItem', $array['itemListElement'][0]['@type']);
+        $this->assertSame('ListItem', $array['itemListElement'][1]['@type']);
+    }
+
+    public function testJsonSerializable(): void
+    {
+        $schema = new SchemaType('Person');
+        $schema->set('name', 'Jane');
+
+        $json = json_encode($schema);
+        $decoded = json_decode($json, true);
+
+        $this->assertSame('Person', $decoded['@type']);
+        $this->assertSame('Jane', $decoded['name']);
+    }
+
+    public function testScalarValuesPassThrough(): void
+    {
+        $schema = new SchemaType('Article');
+        $schema->set('wordCount', 1500);
+        $schema->set('isAccessibleForFree', true);
+
+        $array = $schema->toArray();
+
+        $this->assertSame(1500, $array['wordCount']);
+        $this->assertTrue($array['isAccessibleForFree']);
+    }
+}

--- a/src/Seo/Tests/SchemaValidationTest.php
+++ b/src/Seo/Tests/SchemaValidationTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaManager;
+use BackTo\Framework\Seo\Schema\SchemaType;
+use PHPUnit\Framework\TestCase;
+
+class SchemaValidationTest extends TestCase
+{
+    // --- SchemaType base ---
+
+    public function testGenericSchemaTypeHasNoRequiredProperties(): void
+    {
+        $schema = new SchemaType('Thing');
+        $this->assertSame([], $schema->validate());
+        $this->assertTrue($schema->isValid());
+    }
+
+    // --- Product ---
+
+    public function testProductValidWithAllRequired(): void
+    {
+        $product = Schema::product()
+            ->name('Widget')
+            ->image('https://example.com/img.jpg')
+            ->offers(Schema::offer()->price('10')->priceCurrency('EUR'));
+
+        $this->assertTrue($product->isValid());
+        $this->assertSame([], $product->validate());
+    }
+
+    public function testProductInvalidMissingAll(): void
+    {
+        $product = Schema::product();
+        $missing = $product->validate();
+
+        $this->assertFalse($product->isValid());
+        $this->assertContains('name', $missing);
+        $this->assertContains('image', $missing);
+        $this->assertContains('offers', $missing);
+    }
+
+    public function testProductInvalidMissingPartial(): void
+    {
+        $product = Schema::product()->name('Widget');
+        $missing = $product->validate();
+
+        $this->assertNotContains('name', $missing);
+        $this->assertContains('image', $missing);
+        $this->assertContains('offers', $missing);
+    }
+
+    // --- Article ---
+
+    public function testArticleValidWithAllRequired(): void
+    {
+        $article = Schema::article()
+            ->headline('Title')
+            ->author(Schema::person()->name('John'))
+            ->datePublished('2026-03-15');
+
+        $this->assertTrue($article->isValid());
+    }
+
+    public function testArticleInvalidMissingRequired(): void
+    {
+        $article = Schema::article()->headline('Title');
+        $missing = $article->validate();
+
+        $this->assertFalse($article->isValid());
+        $this->assertContains('author', $missing);
+        $this->assertContains('datePublished', $missing);
+        $this->assertNotContains('headline', $missing);
+    }
+
+    // --- Event ---
+
+    public function testEventValidWithAllRequired(): void
+    {
+        $event = Schema::event()
+            ->name('Concert')
+            ->startDate('2026-06-15')
+            ->location(Schema::place()->name('Salle X'));
+
+        $this->assertTrue($event->isValid());
+    }
+
+    public function testEventInvalidMissingRequired(): void
+    {
+        $event = Schema::event()->name('Concert');
+        $missing = $event->validate();
+
+        $this->assertContains('startDate', $missing);
+        $this->assertContains('location', $missing);
+    }
+
+    // --- Course ---
+
+    public function testCourseValidWithAllRequired(): void
+    {
+        $course = Schema::course()
+            ->name('Formation PHP')
+            ->description('Apprenez PHP')
+            ->provider(Schema::organization()->name('Acme'));
+
+        $this->assertTrue($course->isValid());
+    }
+
+    public function testCourseInvalidMissingRequired(): void
+    {
+        $course = Schema::course()->name('Formation PHP');
+        $missing = $course->validate();
+
+        $this->assertContains('description', $missing);
+        $this->assertContains('provider', $missing);
+    }
+
+    // --- JobPosting ---
+
+    public function testJobPostingValidWithAllRequired(): void
+    {
+        $job = Schema::jobPosting()
+            ->title('Dev PHP')
+            ->description('Poste de dev')
+            ->datePosted('2026-03-15')
+            ->hiringOrganization(Schema::organization()->name('Acme'));
+
+        $this->assertTrue($job->isValid());
+    }
+
+    public function testJobPostingInvalidMissingRequired(): void
+    {
+        $job = Schema::jobPosting()->title('Dev PHP');
+        $missing = $job->validate();
+
+        $this->assertContains('description', $missing);
+        $this->assertContains('datePosted', $missing);
+        $this->assertContains('hiringOrganization', $missing);
+    }
+
+    // --- VideoObject ---
+
+    public function testVideoObjectValidWithAllRequired(): void
+    {
+        $video = Schema::videoObject()
+            ->name('Ma vidéo')
+            ->thumbnailUrl('https://example.com/thumb.jpg')
+            ->uploadDate('2026-03-15');
+
+        $this->assertTrue($video->isValid());
+    }
+
+    public function testVideoObjectInvalidMissingRequired(): void
+    {
+        $video = Schema::videoObject()->name('Ma vidéo');
+        $missing = $video->validate();
+
+        $this->assertContains('thumbnailUrl', $missing);
+        $this->assertContains('uploadDate', $missing);
+    }
+
+    // --- FAQPage ---
+
+    public function testFAQPageValidWithAllRequired(): void
+    {
+        $faq = Schema::faqPage()->mainEntity([
+            Schema::question()->name('Q?')->acceptedAnswer(Schema::answer()->text('A.')),
+        ]);
+
+        $this->assertTrue($faq->isValid());
+    }
+
+    public function testFAQPageInvalidMissingRequired(): void
+    {
+        $faq = Schema::faqPage();
+        $missing = $faq->validate();
+
+        $this->assertContains('mainEntity', $missing);
+    }
+
+    // --- Review ---
+
+    public function testReviewValidWithAllRequired(): void
+    {
+        $review = Schema::review()
+            ->itemReviewed(Schema::product()->name('Widget'))
+            ->reviewRating(Schema::rating()->ratingValue(5))
+            ->author(Schema::person()->name('Jean'));
+
+        $this->assertTrue($review->isValid());
+    }
+
+    public function testReviewInvalidMissingRequired(): void
+    {
+        $review = Schema::review()->reviewBody('Super');
+        $missing = $review->validate();
+
+        $this->assertContains('itemReviewed', $missing);
+        $this->assertContains('reviewRating', $missing);
+        $this->assertContains('author', $missing);
+    }
+
+    // --- LocalBusiness ---
+
+    public function testLocalBusinessValidWithAllRequired(): void
+    {
+        $biz = Schema::localBusiness()
+            ->name('Chez Paul')
+            ->address(Schema::postalAddress()->addressLocality('Paris'));
+
+        $this->assertTrue($biz->isValid());
+    }
+
+    public function testLocalBusinessInvalidMissingRequired(): void
+    {
+        $biz = Schema::localBusiness();
+        $missing = $biz->validate();
+
+        $this->assertContains('name', $missing);
+        $this->assertContains('address', $missing);
+    }
+
+    // --- Offer ---
+
+    public function testOfferValidWithAllRequired(): void
+    {
+        $offer = Schema::offer()->price('10')->priceCurrency('EUR');
+        $this->assertTrue($offer->isValid());
+    }
+
+    public function testOfferInvalidMissingRequired(): void
+    {
+        $offer = Schema::offer()->price('10');
+        $missing = $offer->validate();
+
+        $this->assertContains('priceCurrency', $missing);
+    }
+
+    // --- SchemaManager.validate() ---
+
+    public function testSchemaManagerValidateReturnsEmptyWhenAllValid(): void
+    {
+        $manager = new SchemaManager();
+        $manager->add(Schema::article()->headline('T')->author('A')->datePublished('2026-01-01'));
+        $manager->add(Schema::faqPage()->mainEntity([Schema::question()->name('Q')]));
+
+        $this->assertSame([], $manager->validate());
+    }
+
+    public function testSchemaManagerValidateReturnsErrorsForInvalid(): void
+    {
+        $manager = new SchemaManager();
+        $manager->add(Schema::product()->name('Widget')); // missing image, offers
+        $manager->add(Schema::event()); // missing name, startDate, location
+
+        $errors = $manager->validate();
+
+        $this->assertArrayHasKey('Product', $errors);
+        $this->assertContains('image', $errors['Product']);
+        $this->assertContains('offers', $errors['Product']);
+
+        $this->assertArrayHasKey('Event', $errors);
+        $this->assertContains('name', $errors['Event']);
+        $this->assertContains('startDate', $errors['Event']);
+    }
+
+    public function testSchemaManagerValidateSkipsValidSchemas(): void
+    {
+        $manager = new SchemaManager();
+        $manager->add(Schema::product()->name('W')->image('i.jpg')->offers(Schema::offer()->price('1')->priceCurrency('EUR')));
+        $manager->add(Schema::event()); // invalid
+
+        $errors = $manager->validate();
+
+        $this->assertArrayNotHasKey('Product', $errors);
+        $this->assertArrayHasKey('Event', $errors);
+    }
+}

--- a/src/Seo/Tests/SchemaVideoTest.php
+++ b/src/Seo/Tests/SchemaVideoTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\Schema;
+use BackTo\Framework\Seo\Schema\SchemaManager;
+use BackTo\Framework\Seo\Schema\Type\Clip;
+use BackTo\Framework\Seo\Schema\Type\VideoObject;
+use PHPUnit\Framework\TestCase;
+
+class SchemaVideoTest extends TestCase
+{
+    public function testVideoObjectFactory(): void
+    {
+        $video = Schema::videoObject();
+        $this->assertInstanceOf(VideoObject::class, $video);
+        $this->assertSame('VideoObject', $video->getType());
+    }
+
+    public function testClipFactory(): void
+    {
+        $clip = Schema::clip();
+        $this->assertInstanceOf(Clip::class, $clip);
+        $this->assertSame('Clip', $clip->getType());
+    }
+
+    public function testVideoName(): void
+    {
+        $array = Schema::videoObject()->name('Ma vidéo')->toArray();
+        $this->assertSame('Ma vidéo', $array['name']);
+    }
+
+    public function testVideoDescription(): void
+    {
+        $array = Schema::videoObject()->description('Description de la vidéo')->toArray();
+        $this->assertSame('Description de la vidéo', $array['description']);
+    }
+
+    public function testVideoThumbnailUrlString(): void
+    {
+        $array = Schema::videoObject()->thumbnailUrl('https://example.com/thumb.jpg')->toArray();
+        $this->assertSame('https://example.com/thumb.jpg', $array['thumbnailUrl']);
+    }
+
+    public function testVideoThumbnailUrlArray(): void
+    {
+        $urls = ['https://example.com/thumb1.jpg', 'https://example.com/thumb2.jpg'];
+        $array = Schema::videoObject()->thumbnailUrl($urls)->toArray();
+        $this->assertSame($urls, $array['thumbnailUrl']);
+    }
+
+    public function testVideoUploadDate(): void
+    {
+        $array = Schema::videoObject()->uploadDate('2026-03-15T08:00:00+02:00')->toArray();
+        $this->assertSame('2026-03-15T08:00:00+02:00', $array['uploadDate']);
+    }
+
+    public function testVideoDuration(): void
+    {
+        $array = Schema::videoObject()->duration('PT5M30S')->toArray();
+        $this->assertSame('PT5M30S', $array['duration']);
+    }
+
+    public function testVideoContentUrl(): void
+    {
+        $array = Schema::videoObject()->contentUrl('https://example.com/video.mp4')->toArray();
+        $this->assertSame('https://example.com/video.mp4', $array['contentUrl']);
+    }
+
+    public function testVideoEmbedUrl(): void
+    {
+        $array = Schema::videoObject()->embedUrl('https://youtube.com/embed/abc123')->toArray();
+        $this->assertSame('https://youtube.com/embed/abc123', $array['embedUrl']);
+    }
+
+    public function testVideoExpires(): void
+    {
+        $array = Schema::videoObject()->expires('2027-01-01')->toArray();
+        $this->assertSame('2027-01-01', $array['expires']);
+    }
+
+    public function testVideoRegionsAllowed(): void
+    {
+        $array = Schema::videoObject()->regionsAllowed(['FR', 'BE', 'CH'])->toArray();
+        $this->assertSame(['FR', 'BE', 'CH'], $array['regionsAllowed']);
+    }
+
+    public function testVideoInteractionStatistic(): void
+    {
+        $stat = Schema::type('InteractionCounter')
+            ->set('interactionType', 'https://schema.org/WatchAction')
+            ->set('userInteractionCount', 15000);
+
+        $array = Schema::videoObject()->interactionStatistic($stat)->toArray();
+
+        $this->assertSame('InteractionCounter', $array['interactionStatistic']['@type']);
+        $this->assertSame(15000, $array['interactionStatistic']['userInteractionCount']);
+    }
+
+    public function testVideoPublication(): void
+    {
+        $broadcast = Schema::type('BroadcastEvent')->set('isLiveBroadcast', true);
+        $array = Schema::videoObject()->publication($broadcast)->toArray();
+
+        $this->assertSame('BroadcastEvent', $array['publication']['@type']);
+        $this->assertTrue($array['publication']['isLiveBroadcast']);
+    }
+
+    public function testClipName(): void
+    {
+        $array = Schema::clip()->name('Introduction')->toArray();
+        $this->assertSame('Introduction', $array['name']);
+    }
+
+    public function testClipStartOffset(): void
+    {
+        $array = Schema::clip()->startOffset(30)->toArray();
+        $this->assertSame(30, $array['startOffset']);
+    }
+
+    public function testClipEndOffset(): void
+    {
+        $array = Schema::clip()->endOffset(90)->toArray();
+        $this->assertSame(90, $array['endOffset']);
+    }
+
+    public function testClipUrl(): void
+    {
+        $array = Schema::clip()->url('https://example.com/video#t=30')->toArray();
+        $this->assertSame('https://example.com/video#t=30', $array['url']);
+    }
+
+    public function testVideoWithKeyMoments(): void
+    {
+        $video = Schema::videoObject()
+            ->name('Tutoriel WordPress')
+            ->hasPart([
+                Schema::clip()->name('Introduction')->startOffset(0)->endOffset(30),
+                Schema::clip()->name('Installation')->startOffset(30)->endOffset(120),
+                Schema::clip()->name('Configuration')->startOffset(120)->endOffset(300),
+            ]);
+
+        $array = $video->toArray();
+
+        $this->assertCount(3, $array['hasPart']);
+        $this->assertSame('Clip', $array['hasPart'][0]['@type']);
+        $this->assertSame('Introduction', $array['hasPart'][0]['name']);
+        $this->assertSame(0, $array['hasPart'][0]['startOffset']);
+        $this->assertSame(30, $array['hasPart'][0]['endOffset']);
+        $this->assertSame('Installation', $array['hasPart'][1]['name']);
+        $this->assertSame(30, $array['hasPart'][1]['startOffset']);
+    }
+
+    public function testFullVideoComposition(): void
+    {
+        $video = Schema::videoObject()
+            ->name('Formation SEO 2026')
+            ->description('Apprenez les bases du SEO en 2026')
+            ->thumbnailUrl('https://example.com/seo-thumb.jpg')
+            ->uploadDate('2026-03-01')
+            ->duration('PT45M')
+            ->contentUrl('https://example.com/seo.mp4')
+            ->embedUrl('https://youtube.com/embed/xyz789')
+            ->hasPart([
+                Schema::clip()->name('Intro SEO')->startOffset(0)->endOffset(300)->url('https://youtube.com/watch?v=xyz789&t=0'),
+                Schema::clip()->name('On-page SEO')->startOffset(300)->endOffset(1200)->url('https://youtube.com/watch?v=xyz789&t=300'),
+            ]);
+
+        $array = $video->toArray();
+
+        $this->assertSame('VideoObject', $array['@type']);
+        $this->assertSame('Formation SEO 2026', $array['name']);
+        $this->assertSame('PT45M', $array['duration']);
+        $this->assertSame('https://example.com/seo.mp4', $array['contentUrl']);
+        $this->assertSame('https://youtube.com/embed/xyz789', $array['embedUrl']);
+        $this->assertCount(2, $array['hasPart']);
+    }
+
+    public function testVideoRendersValidJsonLd(): void
+    {
+        $manager = new SchemaManager();
+        $manager->add(
+            Schema::videoObject()
+                ->name('Test Video')
+                ->thumbnailUrl('https://example.com/thumb.jpg')
+                ->uploadDate('2026-03-15')
+        );
+
+        $output = $manager->render();
+
+        preg_match('/<script type="application\/ld\+json">\n(.+)\n<\/script>/s', $output, $matches);
+        $decoded = json_decode($matches[1], true);
+
+        $this->assertSame('https://schema.org', $decoded['@context']);
+        $this->assertSame('VideoObject', $decoded['@type']);
+        $this->assertSame('Test Video', $decoded['name']);
+        $this->assertSame('https://example.com/thumb.jpg', $decoded['thumbnailUrl']);
+    }
+}

--- a/src/Seo/Tests/SeoConfigTest.php
+++ b/src/Seo/Tests/SeoConfigTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Seo\Tests;
+
+use BackTo\Framework\Seo\SeoConfig;
+use PHPUnit\Framework\TestCase;
+
+class SeoConfigTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/seo-config-test-' . uniqid();
+        mkdir($this->tmpDir . '/config', 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $configFile = $this->tmpDir . '/config/seo.php';
+
+        if (file_exists($configFile)) {
+            unlink($configFile);
+        }
+
+        if (is_dir($this->tmpDir . '/config')) {
+            rmdir($this->tmpDir . '/config');
+        }
+
+        if (is_dir($this->tmpDir)) {
+            rmdir($this->tmpDir);
+        }
+    }
+
+    public function testReturnsEmptyConfigWhenFileDoesNotExist(): void
+    {
+        $config = new SeoConfig($this->tmpDir);
+
+        $this->assertSame([], $config->all());
+        $this->assertSame([], $config->getPostTypeMap());
+        $this->assertTrue($config->shouldDisablePluginSchema());
+    }
+
+    public function testLoadsConfigFromFile(): void
+    {
+        $this->writeConfig([
+            'schema' => [
+                'post_type_map' => [
+                    'post' => 'App\\Seo\\ArticleGen',
+                    'formation' => 'App\\Seo\\CourseGen',
+                ],
+                'disable_plugin_schema' => false,
+            ],
+        ]);
+
+        $config = new SeoConfig($this->tmpDir);
+
+        $this->assertSame([
+            'post' => 'App\\Seo\\ArticleGen',
+            'formation' => 'App\\Seo\\CourseGen',
+        ], $config->getPostTypeMap());
+
+        $this->assertFalse($config->shouldDisablePluginSchema());
+    }
+
+    public function testGetNestedValue(): void
+    {
+        $this->writeConfig([
+            'schema' => [
+                'post_type_map' => ['post' => 'ArticleGen'],
+            ],
+        ]);
+
+        $config = new SeoConfig($this->tmpDir);
+
+        $this->assertSame(['post' => 'ArticleGen'], $config->get('schema.post_type_map'));
+        $this->assertSame('ArticleGen', $config->get('schema.post_type_map.post'));
+    }
+
+    public function testGetReturnsDefaultForMissingKey(): void
+    {
+        $config = new SeoConfig($this->tmpDir);
+
+        $this->assertNull($config->get('nonexistent'));
+        $this->assertSame('fallback', $config->get('nonexistent', 'fallback'));
+        $this->assertSame('default', $config->get('schema.deep.missing', 'default'));
+    }
+
+    public function testDisablePluginSchemaDefaultsToTrue(): void
+    {
+        $this->writeConfig(['schema' => []]);
+
+        $config = new SeoConfig($this->tmpDir);
+        $this->assertTrue($config->shouldDisablePluginSchema());
+    }
+
+    public function testHandlesNonArrayReturn(): void
+    {
+        file_put_contents(
+            $this->tmpDir . '/config/seo.php',
+            '<?php return "not an array";'
+        );
+
+        $config = new SeoConfig($this->tmpDir);
+        $this->assertSame([], $config->all());
+    }
+
+    public function testPostTypeMapDefaultsToEmptyArray(): void
+    {
+        $this->writeConfig([]);
+
+        $config = new SeoConfig($this->tmpDir);
+        $this->assertSame([], $config->getPostTypeMap());
+    }
+
+    private function writeConfig(array $data): void
+    {
+        $export = var_export($data, true);
+        file_put_contents(
+            $this->tmpDir . '/config/seo.php',
+            "<?php\n\nreturn {$export};\n"
+        );
+    }
+}


### PR DESCRIPTION
Introduce a fluent builder API for constructing schema.org structured data
with automatic JSON-LD rendering. Includes SchemaManager registry, Schema
factory, concrete types (Organization, Article, BreadcrumbList, WebSite,
LocalBusiness, Person, PostalAddress, ImageObject, SearchAction), and hooks
for wp_head injection and Timber context integration.

https://claude.ai/code/session_01UnGS7W2GK8AnLnn8NCkzu1