### PR TITLE
Add async queue system extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     "backto/security": "self.version",
     "backto/seo": "self.version",
     "backto/taxonomy": "self.version",
+    "backto/queue": "self.version",
     "backto/theme": "self.version"
   },
   "require-dev": {

--- a/docs/explanation/queue-design.md
+++ b/docs/explanation/queue-design.md
@@ -1,0 +1,87 @@
+# Queue System Design
+
+## The problem
+
+WordPress executes PHP synchronously — every operation blocks the HTTP response. Sending emails, processing images, calling external APIs, or running bulk operations during a page request degrades user experience and can trigger timeouts.
+
+WordPress provides `wp_schedule_single_event()` and `wp_cron` for deferred execution, but these are limited:
+
+- No retry logic on failure
+- No visibility into job status
+- No deduplication or grouping
+- No structured payload passing
+- No cleanup of completed tasks
+
+Plugins like Action Scheduler solve this, but adding a third-party dependency to a framework creates coupling and versioning constraints.
+
+## The solution
+
+The Queue module provides a lightweight, framework-native job queue built on the same Clean Architecture patterns as every other module. It stores jobs in a dedicated database table and processes them via WP-Cron.
+
+## Architecture decisions
+
+### Custom table vs. custom post type
+
+Jobs are stored in a `wp_backto_queue_jobs` custom table rather than using WordPress posts. This decision was made for several reasons:
+
+1. **Atomic claiming**: The worker uses `UPDATE ... WHERE status = 'pending' ORDER BY scheduled_at LIMIT 1` to atomically claim a job. This prevents two concurrent cron workers from processing the same job. This pattern is unreliable with `wp_posts` due to WordPress's abstraction layer.
+
+2. **Performance**: A queue generates high write volume (insert, update status, delete). The `wp_posts` table is already a contention point in WordPress — adding queue throughput would degrade overall performance.
+
+3. **Clean lifecycle**: Completed jobs are garbage collected after 24 hours. Using posts would leave orphaned meta rows and pollute the post count.
+
+4. **Dedicated indexes**: The table has indexes optimized for queue access patterns (`status + group + scheduled_at`, `job_key + status`, `status + claimed_at`).
+
+### WP-Cron vs. real cron
+
+The queue hooks into WP-Cron's `every_minute` schedule. This has a well-known limitation: WP-Cron only fires when someone visits the site. For reliable execution:
+
+- Configure a real server-side cron: `* * * * * cd /path/to/wp && php wp-cron.php --doing_wp_cron >/dev/null 2>&1`
+- The framework's `DisablePublicCron` security rule (in the Security module) already recommends and enforces this.
+
+### Groups for sequential processing
+
+Jobs are organized into groups. Within a group, jobs are claimed one at a time in `scheduled_at` order. Different groups are processed independently in the same cron tick.
+
+This allows you to:
+- Isolate slow jobs (image processing) from fast jobs (sending emails)
+- Ensure ordering within a domain (e.g., process payment before sending receipt)
+- Prevent one failing job type from blocking unrelated work
+
+### Retry with fail-then-release
+
+When a job fails:
+
+1. `markFailed()` increments `attempts` and stores the error message
+2. The worker re-reads the job from the database to get the updated count
+3. If `attempts < maxRetries`, `release()` resets the status to `pending`
+4. If retries are exhausted, the job stays in `failed`
+
+This two-step approach (fail → conditionally release) ensures the error is always recorded, even when the job will be retried. It also provides a clean audit trail of how many attempts occurred.
+
+### Recurring job rescheduling
+
+Recurring jobs are not scheduled via WP-Cron recurrence. Instead, the worker enqueues a new job after each successful execution. This approach:
+
+- Prevents job pile-up: if a job takes longer than its interval, the next one is only scheduled after the current one finishes
+- Stops rescheduling on failure: if a recurring job permanently fails, it stops rather than retrying forever
+- Uses the same queue infrastructure for both one-off and recurring work
+
+### Stuck job rescue
+
+A job claimed by a worker that crashes (fatal error, timeout, OOM kill) will remain in `running` status forever. The hourly rescue cron resets any job that has been in `running` for more than 5 minutes back to `pending`.
+
+This timeout is deliberately conservative — most WordPress operations complete in seconds. Jobs that legitimately run longer should be split into smaller units of work.
+
+## Comparison with Action Scheduler
+
+| Feature | BackTo Queue | Action Scheduler |
+|---------|-------------|-----------------|
+| Storage | Custom table | Custom table |
+| Processing | WP-Cron | WP-Cron + async request |
+| Retry | Configurable per job type | Global retry count |
+| Groups | Native support | Via group parameter |
+| Recurring | Re-enqueue after success | Cron-based recurrence |
+| Unique jobs | `dispatchUnique()` deduplication | No built-in dedup |
+| DI integration | Auto-discovered via container | Manual hook registration |
+| Framework coupling | Built on BackTo patterns | Standalone library |

--- a/docs/how-to/use-queue.md
+++ b/docs/how-to/use-queue.md
@@ -1,0 +1,201 @@
+# How to Use the Async Queue System
+
+The Queue module provides a background job processing system for WordPress, similar to Action Scheduler. Jobs are stored in a custom database table and processed via WP-Cron.
+
+## Define a job handler
+
+Create a class that implements `JobInterface`:
+
+```php
+<?php
+
+namespace MyPlugin\Queue;
+
+use BackTo\Framework\Queue\Contracts\JobInterface;
+
+class SendWelcomeEmail implements JobInterface
+{
+    public function getKey(): string
+    {
+        return 'send_welcome_email';
+    }
+
+    public function getLabel(): string
+    {
+        return 'Send Welcome Email';
+    }
+
+    public function getGroup(): string
+    {
+        return 'emails';
+    }
+
+    public function getMaxRetries(): int
+    {
+        return 3;
+    }
+
+    public function handle(array $payload): void
+    {
+        wp_mail(
+            $payload['to'],
+            $payload['subject'],
+            $payload['body']
+        );
+    }
+}
+```
+
+The framework auto-discovers any class implementing `JobInterface`, tags it with `wordpress.queue_job`, and registers it in the `QueueRegistry`.
+
+## Dispatch a job
+
+Inject `QueueDispatcherInterface` in your service and call `dispatch()`:
+
+```php
+use BackTo\Framework\Queue\Contracts\QueueDispatcherInterface;
+
+class UserRegistrationService
+{
+    public function __construct(private QueueDispatcherInterface $dispatcher)
+    {
+    }
+
+    public function register(string $email): void
+    {
+        // ... create user ...
+
+        $this->dispatcher->dispatch('send_welcome_email', [
+            'to' => $email,
+            'subject' => 'Welcome!',
+            'body' => 'Thanks for signing up.',
+        ]);
+    }
+}
+```
+
+The job is enqueued immediately and processed on the next WP-Cron tick (every minute).
+
+## Dispatch with a delay
+
+Delay execution by a number of seconds:
+
+```php
+// Process in 5 minutes
+$this->dispatcher->dispatch('send_welcome_email', $payload, 300);
+```
+
+## Dispatch a unique job
+
+Prevent duplicate jobs with identical key and payload:
+
+```php
+$id = $this->dispatcher->dispatchUnique('sync_inventory', ['sku' => 'ABC123']);
+
+// Returns null if a pending job with the same key + payload already exists
+if ($id === null) {
+    // Duplicate skipped
+}
+```
+
+## Schedule a recurring job
+
+Create a job that re-enqueues itself after each successful execution:
+
+```php
+// Run every hour
+$this->dispatcher->schedule('cleanup_temp_files', 3600);
+
+// With payload and custom group
+$this->dispatcher->schedule('sync_products', 1800, ['source' => 'api'], 'sync');
+```
+
+The recurring job is automatically rescheduled after each successful run. If the job fails and exhausts its retries, rescheduling stops.
+
+## Use queue groups
+
+Groups allow you to organize jobs into separate processing lanes. Jobs within the same group are processed sequentially:
+
+```php
+class ProcessImageJob implements JobInterface
+{
+    public function getGroup(): string
+    {
+        return 'media';
+    }
+
+    // ...
+}
+
+class SendNotificationJob implements JobInterface
+{
+    public function getGroup(): string
+    {
+        return 'notifications';
+    }
+
+    // ...
+}
+```
+
+Each group is processed independently during every cron tick. The `default` group is always processed.
+
+## Configure retry behavior
+
+The `getMaxRetries()` method controls how many times a failed job is retried:
+
+```php
+public function getMaxRetries(): int
+{
+    return 5; // Try up to 5 times before giving up
+}
+```
+
+When a job throws an exception:
+1. The job is marked as `failed` with the error message
+2. The attempt counter is incremented
+3. If attempts < maxRetries, the job is released back to `pending`
+4. If attempts >= maxRetries, the job stays in `failed` status
+
+## Handle errors in jobs
+
+Throw any exception to signal failure. The error message is stored for debugging:
+
+```php
+public function handle(array $payload): void
+{
+    $response = wp_remote_get($payload['url']);
+
+    if (is_wp_error($response)) {
+        throw new \RuntimeException('API call failed: ' . $response->get_error_message());
+    }
+
+    // Process response...
+}
+```
+
+## Activate the queue system
+
+Register the `QueueExtension` in your kernel:
+
+```php
+protected function getExtensions(): array
+{
+    return [
+        // ... other extensions ...
+        new \BackTo\Framework\Queue\QueueExtension(),
+    ];
+}
+```
+
+On plugin activation, the `RegisterQueue` orchestrator creates the `wp_backto_queue_jobs` database table and schedules the cron events. On deactivation, the cron events are cleared.
+
+## Automatic maintenance
+
+The queue system automatically handles:
+
+| Task | Schedule | Description |
+|------|----------|-------------|
+| Process jobs | Every minute | Claims and executes pending jobs from all groups |
+| Rescue stuck jobs | Hourly | Resets jobs stuck in `running` for more than 5 minutes |
+| Cleanup completed | Daily | Deletes completed jobs older than 24 hours |

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,7 @@ Practical guides for accomplishing specific tasks.
 - [How to debug with Query Monitor](how-to/debug-with-query-monitor.md)
 - [How to manage GDPR consent and tracking scripts](how-to/manage-gdpr-consent.md)
 - [How to use WordPress security hardening](how-to/use-security.md)
+- [How to use the async queue system](how-to/use-queue.md)
 
 ## Reference
 
@@ -47,3 +48,4 @@ Background, design decisions, and conceptual understanding.
 - [Clean Architecture and DDD in WordPress](explanation/clean-architecture.md)
 - [Vendor scoping with php-scoper](explanation/vendor-scoping.md)
 - [GDPR consent management design](explanation/gdpr-consent-design.md)
+- [Queue system design](explanation/queue-design.md)

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -88,6 +88,7 @@ Interfaces are auto-tagged in the DI container:
 | `PostMetaStructureInterface` | `wordpress.post_meta` | `RegisterPostMetaStructurePass` |
 | `HookInterface` | `wordpress.hook` | `RegisterHookPass` |
 | `SecurityRuleInterface` | `wordpress.security_rule` | `RegisterSecurityRulePass` |
+| `JobInterface` | `wordpress.queue_job` | `RegisterQueuePass` |
 | `RegistryInterface` | *(set public)* | — |
 
 ## Port bindings (Clean Architecture)
@@ -111,6 +112,7 @@ Port interfaces are bound to WordPress adapters in `WordPressExtension`:
 | `RateLimiterRepositoryInterface` | `WordPressRateLimiterRepository` |
 | `LoginLocationRepositoryInterface` | `WordPressLoginLocationRepository` |
 | `TwoFactorRepositoryInterface` | `WordPressTwoFactorRepository` |
+| `QueueRepositoryInterface` | `WordPressQueueRepository` |
 
 ## Bundle system
 

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -72,6 +72,71 @@ interface ModuleConfiguratorInterface
 
 Implementations: [`AssetsConfigurator`](modules/assets.md#configuration), [`CacheConfigurator`](modules/cache.md#configuration), [`ObservabilityConfigurator`](modules/observability.md#configuration), [`PerformanceConfigurator`](modules/performance.md#configuration), [`RestApiConfigurator`](modules/rest-api.md#configuration), [`SecurityConfigurator`](modules/security.md#configuration), [`SeoConfigurator`](modules/seo.md#configuration).
 
+## Queue contracts
+
+### `JobInterface`
+
+Defines a job handler that can be dispatched to the queue.
+
+```php
+interface JobInterface
+{
+    public function getKey(): string;
+    public function getLabel(): string;
+    public function getGroup(): string;
+    public function getMaxRetries(): int;
+    public function handle(array $payload): void;
+}
+```
+
+### `QueueDispatcherInterface`
+
+Port interface for dispatching jobs.
+
+```php
+interface QueueDispatcherInterface
+{
+    public function dispatch(string $jobKey, array $payload = [], int $delay = 0, string $group = 'default'): int;
+    public function dispatchUnique(string $jobKey, array $payload = [], int $delay = 0, string $group = 'default'): ?int;
+    public function schedule(string $jobKey, int $intervalSeconds, array $payload = [], string $group = 'default'): int;
+}
+```
+
+### `QueueRepositoryInterface`
+
+Port interface for queue job persistence.
+
+```php
+interface QueueRepositoryInterface
+{
+    public function createTable(): void;
+    public function dropTable(): void;
+    public function enqueue(Job $job): int;
+    public function claimNextPending(string $group = 'default'): ?Job;
+    public function markCompleted(int $jobId): void;
+    public function markFailed(int $jobId, string $errorMessage): void;
+    public function release(int $jobId): void;
+    public function find(int $jobId): ?Job;
+    public function findByStatus(JobStatus $status, int $limit = 20, int $offset = 0): array;
+    public function countByStatus(JobStatus $status): int;
+    public function cleanup(int $olderThanSeconds = 86400): int;
+    public function cancel(int $jobId): void;
+    public function rescueStuck(int $timeoutSeconds = 300): int;
+}
+```
+
+### `QueueRegistryInterface`
+
+```php
+interface QueueRegistryInterface
+{
+    public function add(JobInterface $job): self;
+    /** @return JobInterface[] */
+    public function getJobs(): array;
+    public function get(string $key): ?JobInterface;
+}
+```
+
 ## Registry contracts
 
 ### `RegistryInterface`

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -22,6 +22,7 @@ These modules expose public contracts or configuration:
 | [Gdpr](modules/gdpr.md) | GDPR consent management | — |
 | [Security](modules/security.md) | Security hardening (30+ rules, 2FA, CSP, audit log) | `config/security.php` |
 | [Performance](modules/performance.md) | Performance optimization (cache, minification, .htaccess) | `config/performance.php` |
+| [Queue](modules/queue.md) | Async job queue (dispatch, retry, recurring, groups) | — |
 
 ## Other modules
 

--- a/docs/reference/modules/queue.md
+++ b/docs/reference/modules/queue.md
@@ -1,0 +1,127 @@
+# Queue
+
+Async job queue system with background processing via WP-Cron, configurable retries, recurring jobs, and group-based sequential processing.
+
+## Classes
+
+| Class | Role |
+|-------|------|
+| `Entity\Job` | Domain entity holding job state (key, payload, status, attempts) |
+| `Entity\JobStatus` | Enum: Pending, Running, Completed, Failed, Cancelled |
+| `Factory\JobFactory` | Creates `Job` entities and hydrates from DB rows |
+| `QueueRegistry` | Collects registered job handlers |
+| `QueueDispatcher` | Dispatches jobs: `dispatch()`, `dispatchUnique()`, `schedule()` |
+| `QueueWorker` | Processes jobs by batch with retry and recurring rescheduling |
+| `RegisterQueue` | Application orchestrator (WP-Cron, activation, deactivation) |
+| `Contracts\JobInterface` | Interface for job handler definitions |
+| `Contracts\QueueDispatcherInterface` | Port for dispatching jobs |
+| `Contracts\QueueRepositoryInterface` | Port for job persistence |
+| `Contracts\QueueRegistryInterface` | Port for registry access |
+| `Infrastructure\WordPressQueueRepository` | WP adapter (custom `wp_backto_queue_jobs` table) |
+
+## Contracts
+
+### `JobInterface`
+
+Defines a job handler that can be dispatched to the queue.
+
+```php
+interface JobInterface
+{
+    public function getKey(): string;
+    public function getLabel(): string;
+    public function getGroup(): string;
+    public function getMaxRetries(): int;
+    public function handle(array $payload): void;
+}
+```
+
+### `QueueDispatcherInterface`
+
+Port interface for dispatching jobs.
+
+```php
+interface QueueDispatcherInterface
+{
+    public function dispatch(string $jobKey, array $payload = [], int $delay = 0, string $group = 'default'): int;
+    public function dispatchUnique(string $jobKey, array $payload = [], int $delay = 0, string $group = 'default'): ?int;
+    public function schedule(string $jobKey, int $intervalSeconds, array $payload = [], string $group = 'default'): int;
+}
+```
+
+### `QueueRepositoryInterface`
+
+Port interface for queue job persistence.
+
+```php
+interface QueueRepositoryInterface
+{
+    public function createTable(): void;
+    public function dropTable(): void;
+    public function enqueue(Job $job): int;
+    public function claimNextPending(string $group = 'default'): ?Job;
+    public function markCompleted(int $jobId): void;
+    public function markFailed(int $jobId, string $errorMessage): void;
+    public function release(int $jobId): void;
+    public function find(int $jobId): ?Job;
+    public function findByStatus(JobStatus $status, int $limit = 20, int $offset = 0): array;
+    public function countByStatus(JobStatus $status): int;
+    public function cleanup(int $olderThanSeconds = 86400): int;
+    public function cancel(int $jobId): void;
+    public function rescueStuck(int $timeoutSeconds = 300): int;
+}
+```
+
+### `QueueRegistryInterface`
+
+```php
+interface QueueRegistryInterface
+{
+    public function add(JobInterface $job): self;
+    /** @return JobInterface[] */
+    public function getJobs(): array;
+    public function get(string $key): ?JobInterface;
+}
+```
+
+## Autoconfiguration
+
+Classes implementing `JobInterface` are automatically tagged `wordpress.queue_job` and registered in the `QueueRegistry` via the `RegisterQueuePass` compiler pass.
+
+## Database schema
+
+The `wp_backto_queue_jobs` table is created on plugin activation:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | `BIGINT AUTO_INCREMENT` | Primary key |
+| `job_key` | `VARCHAR(255)` | Job handler identifier |
+| `payload` | `LONGTEXT` | JSON-encoded job data |
+| `status` | `VARCHAR(20)` | pending, running, completed, failed, cancelled |
+| `group_name` | `VARCHAR(100)` | Processing group |
+| `attempts` | `INT` | Number of execution attempts |
+| `max_retries` | `INT` | Maximum allowed retries |
+| `error_message` | `TEXT` | Last error message (nullable) |
+| `scheduled_at` | `DATETIME` | When the job should be processed |
+| `claimed_at` | `DATETIME` | When a worker claimed the job (nullable) |
+| `completed_at` | `DATETIME` | When the job finished (nullable) |
+| `recurring_interval` | `INT` | Seconds between recurring executions (nullable) |
+| `created_at` | `DATETIME` | Row creation timestamp |
+| `updated_at` | `DATETIME` | Last modification timestamp |
+
+### Indexes
+
+| Index | Columns | Purpose |
+|-------|---------|---------|
+| `idx_status_group_scheduled` | `status`, `group_name`, `scheduled_at` | Claim next pending job |
+| `idx_job_key_status` | `job_key`, `status` | Unique job deduplication |
+| `idx_status_claimed` | `status`, `claimed_at` | Rescue stuck jobs |
+| `idx_status_completed` | `status`, `completed_at` | Cleanup completed jobs |
+
+## Cron events
+
+| Event | Schedule | Handler |
+|-------|----------|---------|
+| `backto_queue_process` | Every minute | `QueueWorker::processAll()` |
+| `backto_queue_rescue` | Hourly | `QueueWorker::rescueStuck()` |
+| `backto_queue_cleanup` | Daily | `QueueWorker::cleanup()` |

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -63,6 +63,9 @@
         <testsuite name="performance">
             <directory>src/Performance/Tests</directory>
         </testsuite>
+        <testsuite name="queue">
+            <directory>src/Queue/Tests</directory>
+        </testsuite>
     </testsuites>
 
     <coverage cacheDirectory=".phpunit.cache/code-coverage">

--- a/src/Queue/Contracts/JobInterface.php
+++ b/src/Queue/Contracts/JobInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Contracts;
+
+/**
+ * Represents an async job that can be dispatched to a queue.
+ *
+ * Implement this interface to define jobs processed in the background.
+ * Each job class is auto-tagged and registered in the QueueRegistry.
+ */
+interface JobInterface
+{
+    /**
+     * Get the unique identifier for this job type.
+     *
+     * Used as the action hook name for dispatching.
+     */
+    public function getKey(): string;
+
+    /**
+     * Get the human-readable label for this job.
+     */
+    public function getLabel(): string;
+
+    /**
+     * Get the queue group this job belongs to.
+     *
+     * Jobs within the same group are processed sequentially.
+     * Defaults to 'default'.
+     */
+    public function getGroup(): string;
+
+    /**
+     * Get the maximum number of retry attempts.
+     */
+    public function getMaxRetries(): int;
+
+    /**
+     * Handle the job execution.
+     *
+     * @param array<string, mixed> $payload The job payload data.
+     *
+     * @throws \Throwable If the job fails, it will be retried up to maxRetries.
+     */
+    public function handle(array $payload): void;
+}

--- a/src/Queue/Contracts/QueueDispatcherInterface.php
+++ b/src/Queue/Contracts/QueueDispatcherInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Contracts;
+
+use BackTo\Framework\Queue\Entity\Job;
+
+/**
+ * Port interface for dispatching jobs to the queue.
+ */
+interface QueueDispatcherInterface
+{
+    /**
+     * Dispatch a job for async processing.
+     *
+     * @param string $jobKey The job type key (matching JobInterface::getKey()).
+     * @param array<string, mixed> $payload Data to pass to the job handler.
+     * @param int $delay Number of seconds to delay before the job becomes available.
+     * @param string $group The queue group for sequential processing.
+     *
+     * @return int The enqueued job ID.
+     */
+    public function dispatch(string $jobKey, array $payload = [], int $delay = 0, string $group = 'default'): int;
+
+    /**
+     * Dispatch a unique job — skips if an identical pending job already exists.
+     *
+     * @param string $jobKey The job type key.
+     * @param array<string, mixed> $payload Data to pass to the job handler.
+     * @param int $delay Number of seconds to delay.
+     * @param string $group The queue group.
+     *
+     * @return int|null The job ID, or null if a duplicate was skipped.
+     */
+    public function dispatchUnique(string $jobKey, array $payload = [], int $delay = 0, string $group = 'default'): ?int;
+
+    /**
+     * Schedule a recurring job.
+     *
+     * @param string $jobKey The job type key.
+     * @param int $intervalSeconds The interval between recurrences.
+     * @param array<string, mixed> $payload Data to pass to the job handler.
+     * @param string $group The queue group.
+     *
+     * @return int The enqueued job ID.
+     */
+    public function schedule(string $jobKey, int $intervalSeconds, array $payload = [], string $group = 'default'): int;
+}

--- a/src/Queue/Contracts/QueueRegistryInterface.php
+++ b/src/Queue/Contracts/QueueRegistryInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Contracts;
+
+/**
+ * Registry for collecting job handler definitions.
+ */
+interface QueueRegistryInterface
+{
+    public function add(JobInterface $job): self;
+
+    /**
+     * @return JobInterface[]
+     */
+    public function getJobs(): array;
+
+    /**
+     * Find a job handler by its key.
+     */
+    public function get(string $key): ?JobInterface;
+}

--- a/src/Queue/Contracts/QueueRepositoryInterface.php
+++ b/src/Queue/Contracts/QueueRepositoryInterface.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Contracts;
+
+use BackTo\Framework\Queue\Entity\Job;
+use BackTo\Framework\Queue\Entity\JobStatus;
+
+/**
+ * Port interface for queue storage.
+ *
+ * Abstracts the persistence layer for queued jobs.
+ */
+interface QueueRepositoryInterface
+{
+    /**
+     * Create the storage table if it does not exist.
+     */
+    public function createTable(): void;
+
+    /**
+     * Drop the storage table.
+     */
+    public function dropTable(): void;
+
+    /**
+     * Insert a new job into the queue.
+     */
+    public function enqueue(Job $job): int;
+
+    /**
+     * Claim the next pending job for a given group.
+     *
+     * Atomically marks a pending job as running to prevent
+     * concurrent workers from processing the same job.
+     */
+    public function claimNextPending(string $group = 'default'): ?Job;
+
+    /**
+     * Mark a job as completed.
+     */
+    public function markCompleted(int $jobId): void;
+
+    /**
+     * Mark a job as failed and increment attempts.
+     */
+    public function markFailed(int $jobId, string $errorMessage): void;
+
+    /**
+     * Release a failed job back to pending status for retry.
+     */
+    public function release(int $jobId): void;
+
+    /**
+     * Find a job by its ID.
+     */
+    public function find(int $jobId): ?Job;
+
+    /**
+     * Find jobs by status.
+     *
+     * @return Job[]
+     */
+    public function findByStatus(JobStatus $status, int $limit = 20, int $offset = 0): array;
+
+    /**
+     * Count jobs by status.
+     */
+    public function countByStatus(JobStatus $status): int;
+
+    /**
+     * Delete completed jobs older than the given number of seconds.
+     */
+    public function cleanup(int $olderThanSeconds = 86400): int;
+
+    /**
+     * Cancel a pending job.
+     */
+    public function cancel(int $jobId): void;
+
+    /**
+     * Rescue stuck running jobs older than the given timeout in seconds.
+     *
+     * Jobs that have been running longer than the timeout are
+     * considered stuck and will be released back to pending.
+     */
+    public function rescueStuck(int $timeoutSeconds = 300): int;
+}

--- a/src/Queue/Contracts/QueueRepositoryInterface.php
+++ b/src/Queue/Contracts/QueueRepositoryInterface.php
@@ -75,6 +75,11 @@ interface QueueRepositoryInterface
     public function cleanup(int $olderThanSeconds = 86400): int;
 
     /**
+     * Delete failed jobs (retries exhausted) older than the given number of seconds.
+     */
+    public function cleanupFailed(int $olderThanSeconds = 604800): int;
+
+    /**
      * Cancel a pending job.
      */
     public function cancel(int $jobId): void;
@@ -86,4 +91,19 @@ interface QueueRepositoryInterface
      * considered stuck and will be released back to pending.
      */
     public function rescueStuck(int $timeoutSeconds = 300): int;
+
+    /**
+     * Check if a pending job with the given key and payload hash exists.
+     *
+     * @param string $jobKey The job type key.
+     * @param string $payloadHash MD5 hash of the JSON-encoded payload.
+     */
+    public function hasPendingDuplicate(string $jobKey, string $payloadHash): bool;
+
+    /**
+     * Get all distinct group names that have pending or running jobs.
+     *
+     * @return string[]
+     */
+    public function getActiveGroups(): array;
 }

--- a/src/Queue/DependencyInjection/Compiler/RegisterQueuePass.php
+++ b/src/Queue/DependencyInjection/Compiler/RegisterQueuePass.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\DependencyInjection\Compiler;
+
+use BackTo\Framework\Compose\DependencyInjection\Compiler\AbstractTaggedServiceCompilerPass;
+use BackTo\Framework\Queue\QueueRegistry;
+
+class RegisterQueuePass extends AbstractTaggedServiceCompilerPass
+{
+    protected function getRegistryClass(): string
+    {
+        return QueueRegistry::class;
+    }
+
+    protected function getTag(): string
+    {
+        return 'wordpress.queue_job';
+    }
+}

--- a/src/Queue/Entity/Job.php
+++ b/src/Queue/Entity/Job.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Entity;
+
+/**
+ * Represents a queued job instance with its state and metadata.
+ */
+class Job
+{
+    private int $id = 0;
+    private string $key = '';
+    private string $group = 'default';
+
+    /** @var array<string, mixed> */
+    private array $payload = [];
+    private JobStatus $status = JobStatus::Pending;
+    private int $attempts = 0;
+    private int $maxRetries = 3;
+    private string $lastError = '';
+    private ?\DateTimeImmutable $scheduledAt = null;
+    private ?\DateTimeImmutable $claimedAt = null;
+    private ?\DateTimeImmutable $completedAt = null;
+    private ?\DateTimeImmutable $createdAt = null;
+    private int $intervalSeconds = 0;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    public function setKey(string $key): self
+    {
+        $this->key = $key;
+
+        return $this;
+    }
+
+    public function getGroup(): string
+    {
+        return $this->group;
+    }
+
+    public function setGroup(string $group): self
+    {
+        $this->group = $group;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function setPayload(array $payload): self
+    {
+        $this->payload = $payload;
+
+        return $this;
+    }
+
+    public function getStatus(): JobStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(JobStatus $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getAttempts(): int
+    {
+        return $this->attempts;
+    }
+
+    public function setAttempts(int $attempts): self
+    {
+        $this->attempts = $attempts;
+
+        return $this;
+    }
+
+    public function getMaxRetries(): int
+    {
+        return $this->maxRetries;
+    }
+
+    public function setMaxRetries(int $maxRetries): self
+    {
+        $this->maxRetries = $maxRetries;
+
+        return $this;
+    }
+
+    public function getLastError(): string
+    {
+        return $this->lastError;
+    }
+
+    public function setLastError(string $lastError): self
+    {
+        $this->lastError = $lastError;
+
+        return $this;
+    }
+
+    public function getScheduledAt(): ?\DateTimeImmutable
+    {
+        return $this->scheduledAt;
+    }
+
+    public function setScheduledAt(?\DateTimeImmutable $scheduledAt): self
+    {
+        $this->scheduledAt = $scheduledAt;
+
+        return $this;
+    }
+
+    public function getClaimedAt(): ?\DateTimeImmutable
+    {
+        return $this->claimedAt;
+    }
+
+    public function setClaimedAt(?\DateTimeImmutable $claimedAt): self
+    {
+        $this->claimedAt = $claimedAt;
+
+        return $this;
+    }
+
+    public function getCompletedAt(): ?\DateTimeImmutable
+    {
+        return $this->completedAt;
+    }
+
+    public function setCompletedAt(?\DateTimeImmutable $completedAt): self
+    {
+        $this->completedAt = $completedAt;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): ?\DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getIntervalSeconds(): int
+    {
+        return $this->intervalSeconds;
+    }
+
+    public function setIntervalSeconds(int $intervalSeconds): self
+    {
+        $this->intervalSeconds = $intervalSeconds;
+
+        return $this;
+    }
+
+    public function isRecurring(): bool
+    {
+        return $this->intervalSeconds > 0;
+    }
+
+    public function isReady(): bool
+    {
+        if ($this->status !== JobStatus::Pending) {
+            return false;
+        }
+
+        if ($this->scheduledAt === null) {
+            return true;
+        }
+
+        return $this->scheduledAt <= new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+    }
+
+    public function canRetry(): bool
+    {
+        return $this->attempts < $this->maxRetries;
+    }
+}

--- a/src/Queue/Entity/Job.php
+++ b/src/Queue/Entity/Job.php
@@ -15,14 +15,17 @@ class Job
 
     /** @var array<string, mixed> */
     private array $payload = [];
+    private string $payloadHash = '';
     private JobStatus $status = JobStatus::Pending;
     private int $attempts = 0;
     private int $maxRetries = 3;
     private string $lastError = '';
+    private string $claimToken = '';
     private ?\DateTimeImmutable $scheduledAt = null;
     private ?\DateTimeImmutable $claimedAt = null;
     private ?\DateTimeImmutable $completedAt = null;
     private ?\DateTimeImmutable $createdAt = null;
+    private ?\DateTimeImmutable $updatedAt = null;
     private int $intervalSeconds = 0;
 
     public function getId(): int
@@ -79,6 +82,18 @@ class Job
         return $this;
     }
 
+    public function getPayloadHash(): string
+    {
+        return $this->payloadHash;
+    }
+
+    public function setPayloadHash(string $payloadHash): self
+    {
+        $this->payloadHash = $payloadHash;
+
+        return $this;
+    }
+
     public function getStatus(): JobStatus
     {
         return $this->status;
@@ -127,6 +142,18 @@ class Job
         return $this;
     }
 
+    public function getClaimToken(): string
+    {
+        return $this->claimToken;
+    }
+
+    public function setClaimToken(string $claimToken): self
+    {
+        $this->claimToken = $claimToken;
+
+        return $this;
+    }
+
     public function getScheduledAt(): ?\DateTimeImmutable
     {
         return $this->scheduledAt;
@@ -171,6 +198,18 @@ class Job
     public function setCreatedAt(?\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    public function getUpdatedAt(): ?\DateTimeImmutable
+    {
+        return $this->updatedAt;
+    }
+
+    public function setUpdatedAt(?\DateTimeImmutable $updatedAt): self
+    {
+        $this->updatedAt = $updatedAt;
 
         return $this;
     }

--- a/src/Queue/Entity/JobStatus.php
+++ b/src/Queue/Entity/JobStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Entity;
+
+enum JobStatus: string
+{
+    case Pending = 'pending';
+    case Running = 'running';
+    case Completed = 'completed';
+    case Failed = 'failed';
+    case Cancelled = 'cancelled';
+}

--- a/src/Queue/Factory/JobFactory.php
+++ b/src/Queue/Factory/JobFactory.php
@@ -10,6 +10,10 @@ use BackTo\Framework\Queue\Entity\JobStatus;
 
 class JobFactory
 {
+    private const MAX_KEY_LENGTH = 255;
+    private const MAX_GROUP_LENGTH = 255;
+    private const MAX_ERROR_LENGTH = 5000;
+
     /**
      * Create a new Job entity ready for enqueuing.
      *
@@ -32,15 +36,34 @@ class JobFactory
             throw new FrameworkException('Job key cannot be empty.');
         }
 
+        if (\strlen($key) > self::MAX_KEY_LENGTH) {
+            throw new FrameworkException(\sprintf('Job key cannot exceed %d characters.', self::MAX_KEY_LENGTH));
+        }
+
+        if (\strlen($group) > self::MAX_GROUP_LENGTH) {
+            throw new FrameworkException(\sprintf('Job group cannot exceed %d characters.', self::MAX_GROUP_LENGTH));
+        }
+
+        if ($delay < 0) {
+            $delay = 0;
+        }
+
+        if ($intervalSeconds < 0) {
+            $intervalSeconds = 0;
+        }
+
         $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
         $scheduledAt = $delay > 0
             ? $now->modify("+{$delay} seconds")
             : $now;
 
+        $payloadJson = \json_encode($payload, \JSON_THROW_ON_ERROR);
+
         $job = new Job();
         $job->setKey($key)
             ->setGroup($group)
             ->setPayload($payload)
+            ->setPayloadHash(\md5($payloadJson))
             ->setStatus(JobStatus::Pending)
             ->setAttempts(0)
             ->setMaxRetries($maxRetries)
@@ -63,17 +86,32 @@ class JobFactory
             ->setKey((string) ($row['job_key'] ?? ''))
             ->setGroup((string) ($row['job_group'] ?? 'default'))
             ->setPayload($this->decodePayload((string) ($row['payload'] ?? '[]')))
+            ->setPayloadHash((string) ($row['payload_hash'] ?? ''))
             ->setStatus(JobStatus::tryFrom((string) ($row['status'] ?? '')) ?? JobStatus::Pending)
             ->setAttempts((int) ($row['attempts'] ?? 0))
             ->setMaxRetries((int) ($row['max_retries'] ?? 3))
             ->setLastError((string) ($row['last_error'] ?? ''))
+            ->setClaimToken((string) ($row['claim_token'] ?? ''))
             ->setScheduledAt($this->parseDate((string) ($row['scheduled_at'] ?? '')))
             ->setClaimedAt($this->parseDate((string) ($row['claimed_at'] ?? '')))
             ->setCompletedAt($this->parseDate((string) ($row['completed_at'] ?? '')))
             ->setCreatedAt($this->parseDate((string) ($row['created_at'] ?? '')))
+            ->setUpdatedAt($this->parseDate((string) ($row['updated_at'] ?? '')))
             ->setIntervalSeconds((int) ($row['interval_seconds'] ?? 0));
 
         return $job;
+    }
+
+    /**
+     * Truncate an error message to a safe length.
+     */
+    public static function truncateError(string $message): string
+    {
+        if (\strlen($message) <= self::MAX_ERROR_LENGTH) {
+            return $message;
+        }
+
+        return \substr($message, 0, self::MAX_ERROR_LENGTH - 12) . ' [truncated]';
     }
 
     /**

--- a/src/Queue/Factory/JobFactory.php
+++ b/src/Queue/Factory/JobFactory.php
@@ -13,6 +13,7 @@ class JobFactory
     private const MAX_KEY_LENGTH = 255;
     private const MAX_GROUP_LENGTH = 255;
     private const MAX_ERROR_LENGTH = 5000;
+    private const MAX_PAYLOAD_BYTES = 1048576; // 1 MB
 
     /**
      * Create a new Job entity ready for enqueuing.
@@ -59,6 +60,14 @@ class JobFactory
 
         $payloadJson = \json_encode($payload, \JSON_THROW_ON_ERROR);
 
+        if (\strlen($payloadJson) > self::MAX_PAYLOAD_BYTES) {
+            throw new FrameworkException(\sprintf(
+                'Job payload exceeds maximum size of %d bytes (%d bytes given).',
+                self::MAX_PAYLOAD_BYTES,
+                \strlen($payloadJson)
+            ));
+        }
+
         $job = new Job();
         $job->setKey($key)
             ->setGroup($group)
@@ -100,6 +109,27 @@ class JobFactory
             ->setIntervalSeconds((int) ($row['interval_seconds'] ?? 0));
 
         return $job;
+    }
+
+    /**
+     * Sanitize and truncate an error message for safe storage.
+     *
+     * Strips file paths, connection strings, and potential credentials
+     * to prevent sensitive information leakage (CWE-209).
+     */
+    public static function sanitizeError(string $message): string
+    {
+        // Strip absolute file paths (Unix and Windows).
+        $message = (string) \preg_replace('#(/[a-zA-Z0-9._\-]+){3,}(\.\w+)?#', '[path]', $message);
+        $message = (string) \preg_replace('#[A-Z]:\\\\([^\s\\\\]+\\\\){2,}#', '[path]', $message);
+
+        // Strip connection strings (mysql://, pgsql://, redis://, etc.).
+        $message = (string) \preg_replace('#\w+://[^\s]+@[^\s]+#', '[redacted-dsn]', $message);
+
+        // Strip potential API keys / tokens (long hex or base64 strings, 32+ chars).
+        $message = (string) \preg_replace('#(?<![a-zA-Z0-9])[a-zA-Z0-9+/=_\-]{32,}(?![a-zA-Z0-9])#', '[redacted]', $message);
+
+        return self::truncateError($message);
     }
 
     /**

--- a/src/Queue/Factory/JobFactory.php
+++ b/src/Queue/Factory/JobFactory.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Factory;
+
+use BackTo\Framework\Exception\FrameworkException;
+use BackTo\Framework\Queue\Entity\Job;
+use BackTo\Framework\Queue\Entity\JobStatus;
+
+class JobFactory
+{
+    /**
+     * Create a new Job entity ready for enqueuing.
+     *
+     * @param string $key The job type key.
+     * @param array<string, mixed> $payload The job payload.
+     * @param string $group The queue group.
+     * @param int $maxRetries Maximum retry attempts.
+     * @param int $delay Seconds to delay execution.
+     * @param int $intervalSeconds Recurrence interval (0 = one-off).
+     */
+    public function create(
+        string $key,
+        array $payload = [],
+        string $group = 'default',
+        int $maxRetries = 3,
+        int $delay = 0,
+        int $intervalSeconds = 0
+    ): Job {
+        if ($key === '') {
+            throw new FrameworkException('Job key cannot be empty.');
+        }
+
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $scheduledAt = $delay > 0
+            ? $now->modify("+{$delay} seconds")
+            : $now;
+
+        $job = new Job();
+        $job->setKey($key)
+            ->setGroup($group)
+            ->setPayload($payload)
+            ->setStatus(JobStatus::Pending)
+            ->setAttempts(0)
+            ->setMaxRetries($maxRetries)
+            ->setScheduledAt($scheduledAt)
+            ->setCreatedAt($now)
+            ->setIntervalSeconds($intervalSeconds);
+
+        return $job;
+    }
+
+    /**
+     * Hydrate a Job entity from a database row.
+     *
+     * @param array<string, mixed> $row
+     */
+    public function fromRow(array $row): Job
+    {
+        $job = new Job();
+        $job->setId((int) ($row['id'] ?? 0))
+            ->setKey((string) ($row['job_key'] ?? ''))
+            ->setGroup((string) ($row['job_group'] ?? 'default'))
+            ->setPayload($this->decodePayload((string) ($row['payload'] ?? '[]')))
+            ->setStatus(JobStatus::tryFrom((string) ($row['status'] ?? '')) ?? JobStatus::Pending)
+            ->setAttempts((int) ($row['attempts'] ?? 0))
+            ->setMaxRetries((int) ($row['max_retries'] ?? 3))
+            ->setLastError((string) ($row['last_error'] ?? ''))
+            ->setScheduledAt($this->parseDate((string) ($row['scheduled_at'] ?? '')))
+            ->setClaimedAt($this->parseDate((string) ($row['claimed_at'] ?? '')))
+            ->setCompletedAt($this->parseDate((string) ($row['completed_at'] ?? '')))
+            ->setCreatedAt($this->parseDate((string) ($row['created_at'] ?? '')))
+            ->setIntervalSeconds((int) ($row['interval_seconds'] ?? 0));
+
+        return $job;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodePayload(string $json): array
+    {
+        if ($json === '' || $json === '[]') {
+            return [];
+        }
+
+        $decoded = \json_decode($json, true);
+
+        return \is_array($decoded) ? $decoded : [];
+    }
+
+    private function parseDate(string $date): ?\DateTimeImmutable
+    {
+        if ($date === '' || $date === '0000-00-00 00:00:00') {
+            return null;
+        }
+
+        $parsed = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', $date, new \DateTimeZone('UTC'));
+
+        return $parsed !== false ? $parsed : null;
+    }
+}

--- a/src/Queue/Infrastructure/WordPressQueueRepository.php
+++ b/src/Queue/Infrastructure/WordPressQueueRepository.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Infrastructure;
+
+use BackTo\Framework\Queue\Contracts\QueueRepositoryInterface;
+use BackTo\Framework\Queue\Entity\Job;
+use BackTo\Framework\Queue\Entity\JobStatus;
+use BackTo\Framework\Queue\Factory\JobFactory;
+
+/**
+ * WordPress adapter for queue persistence using a custom database table.
+ */
+class WordPressQueueRepository implements QueueRepositoryInterface
+{
+    private JobFactory $factory;
+    private string $table;
+
+    public function __construct(JobFactory $factory)
+    {
+        global $wpdb;
+
+        $this->factory = $factory;
+        $this->table = $wpdb->prefix . 'backto_queue_jobs';
+    }
+
+    public function createTable(): void
+    {
+        global $wpdb;
+
+        $charset = $wpdb->get_charset_collate();
+
+        $sql = "CREATE TABLE IF NOT EXISTS {$this->table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            job_key VARCHAR(255) NOT NULL,
+            job_group VARCHAR(255) NOT NULL DEFAULT 'default',
+            payload LONGTEXT NOT NULL DEFAULT '[]',
+            status VARCHAR(20) NOT NULL DEFAULT 'pending',
+            attempts INT UNSIGNED NOT NULL DEFAULT 0,
+            max_retries INT UNSIGNED NOT NULL DEFAULT 3,
+            last_error TEXT NOT NULL DEFAULT '',
+            interval_seconds INT UNSIGNED NOT NULL DEFAULT 0,
+            scheduled_at DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
+            claimed_at DATETIME DEFAULT NULL,
+            completed_at DATETIME DEFAULT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            KEY idx_status_group_scheduled (status, job_group, scheduled_at),
+            KEY idx_job_key_status (job_key, status),
+            KEY idx_status_claimed (status, claimed_at)
+        ) {$charset};";
+
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        \dbDelta($sql);
+    }
+
+    public function dropTable(): void
+    {
+        global $wpdb;
+
+        $wpdb->query("DROP TABLE IF EXISTS {$this->table}");
+    }
+
+    public function enqueue(Job $job): int
+    {
+        global $wpdb;
+
+        $wpdb->insert(
+            $this->table,
+            [
+                'job_key' => $job->getKey(),
+                'job_group' => $job->getGroup(),
+                'payload' => \wp_json_encode($job->getPayload()),
+                'status' => $job->getStatus()->value,
+                'attempts' => $job->getAttempts(),
+                'max_retries' => $job->getMaxRetries(),
+                'interval_seconds' => $job->getIntervalSeconds(),
+                'scheduled_at' => $job->getScheduledAt()?->format('Y-m-d H:i:s') ?? \gmdate('Y-m-d H:i:s'),
+                'created_at' => $job->getCreatedAt()?->format('Y-m-d H:i:s') ?? \gmdate('Y-m-d H:i:s'),
+            ],
+            ['%s', '%s', '%s', '%s', '%d', '%d', '%d', '%s', '%s']
+        );
+
+        return (int) $wpdb->insert_id;
+    }
+
+    public function claimNextPending(string $group = 'default'): ?Job
+    {
+        global $wpdb;
+
+        $now = \gmdate('Y-m-d H:i:s');
+
+        // Atomic claim: UPDATE with WHERE ensures only one worker gets the job.
+        $updated = $wpdb->query(
+            $wpdb->prepare(
+                "UPDATE {$this->table}
+                 SET status = %s, claimed_at = %s
+                 WHERE status = %s
+                   AND job_group = %s
+                   AND scheduled_at <= %s
+                 ORDER BY scheduled_at ASC, id ASC
+                 LIMIT 1",
+                JobStatus::Running->value,
+                $now,
+                JobStatus::Pending->value,
+                $group,
+                $now
+            )
+        );
+
+        if ($updated === 0 || $updated === false) {
+            return null;
+        }
+
+        $row = $wpdb->get_row(
+            $wpdb->prepare(
+                "SELECT * FROM {$this->table}
+                 WHERE status = %s AND job_group = %s AND claimed_at = %s
+                 ORDER BY id DESC LIMIT 1",
+                JobStatus::Running->value,
+                $group,
+                $now
+            ),
+            ARRAY_A
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $row */
+        return $this->factory->fromRow($row);
+    }
+
+    public function markCompleted(int $jobId): void
+    {
+        global $wpdb;
+
+        $wpdb->update(
+            $this->table,
+            [
+                'status' => JobStatus::Completed->value,
+                'completed_at' => \gmdate('Y-m-d H:i:s'),
+            ],
+            ['id' => $jobId],
+            ['%s', '%s'],
+            ['%d']
+        );
+    }
+
+    public function markFailed(int $jobId, string $errorMessage): void
+    {
+        global $wpdb;
+
+        $wpdb->query(
+            $wpdb->prepare(
+                "UPDATE {$this->table}
+                 SET status = %s, last_error = %s, attempts = attempts + 1
+                 WHERE id = %d",
+                JobStatus::Failed->value,
+                $errorMessage,
+                $jobId
+            )
+        );
+    }
+
+    public function release(int $jobId): void
+    {
+        global $wpdb;
+
+        $wpdb->update(
+            $this->table,
+            [
+                'status' => JobStatus::Pending->value,
+                'claimed_at' => null,
+            ],
+            ['id' => $jobId],
+            ['%s', null],
+            ['%d']
+        );
+    }
+
+    public function find(int $jobId): ?Job
+    {
+        global $wpdb;
+
+        $row = $wpdb->get_row(
+            $wpdb->prepare("SELECT * FROM {$this->table} WHERE id = %d", $jobId),
+            ARRAY_A
+        );
+
+        if ($row === null) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $row */
+        return $this->factory->fromRow($row);
+    }
+
+    /**
+     * @return Job[]
+     */
+    public function findByStatus(JobStatus $status, int $limit = 20, int $offset = 0): array
+    {
+        global $wpdb;
+
+        $rows = $wpdb->get_results(
+            $wpdb->prepare(
+                "SELECT * FROM {$this->table} WHERE status = %s ORDER BY created_at DESC LIMIT %d OFFSET %d",
+                $status->value,
+                $limit,
+                $offset
+            ),
+            ARRAY_A
+        );
+
+        if (!\is_array($rows)) {
+            return [];
+        }
+
+        return \array_map(fn (array $row): Job => $this->factory->fromRow($row), $rows);
+    }
+
+    public function countByStatus(JobStatus $status): int
+    {
+        global $wpdb;
+
+        return (int) $wpdb->get_var(
+            $wpdb->prepare("SELECT COUNT(*) FROM {$this->table} WHERE status = %s", $status->value)
+        );
+    }
+
+    public function cleanup(int $olderThanSeconds = 86400): int
+    {
+        global $wpdb;
+
+        $cutoff = \gmdate('Y-m-d H:i:s', \time() - $olderThanSeconds);
+
+        return (int) $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$this->table} WHERE status = %s AND completed_at < %s",
+                JobStatus::Completed->value,
+                $cutoff
+            )
+        );
+    }
+
+    public function cancel(int $jobId): void
+    {
+        global $wpdb;
+
+        $wpdb->update(
+            $this->table,
+            ['status' => JobStatus::Cancelled->value],
+            ['id' => $jobId, 'status' => JobStatus::Pending->value],
+            ['%s'],
+            ['%d', '%s']
+        );
+    }
+
+    public function rescueStuck(int $timeoutSeconds = 300): int
+    {
+        global $wpdb;
+
+        $cutoff = \gmdate('Y-m-d H:i:s', \time() - $timeoutSeconds);
+
+        return (int) $wpdb->query(
+            $wpdb->prepare(
+                "UPDATE {$this->table}
+                 SET status = %s, claimed_at = NULL
+                 WHERE status = %s AND claimed_at < %s",
+                JobStatus::Pending->value,
+                JobStatus::Running->value,
+                $cutoff
+            )
+        );
+    }
+
+    /**
+     * Check if a pending job with the given key and payload already exists.
+     */
+    public function hasPendingDuplicate(string $jobKey, string $payloadJson): bool
+    {
+        global $wpdb;
+
+        $count = (int) $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT COUNT(*) FROM {$this->table}
+                 WHERE job_key = %s AND payload = %s AND status = %s",
+                $jobKey,
+                $payloadJson,
+                JobStatus::Pending->value
+            )
+        );
+
+        return $count > 0;
+    }
+}

--- a/src/Queue/Infrastructure/WordPressQueueRepository.php
+++ b/src/Queue/Infrastructure/WordPressQueueRepository.php
@@ -152,9 +152,10 @@ class WordPressQueueRepository implements QueueRepositoryInterface
             [
                 'status' => JobStatus::Completed->value,
                 'completed_at' => \gmdate('Y-m-d H:i:s'),
+                'claim_token' => '',
             ],
             ['id' => $jobId],
-            ['%s', '%s'],
+            ['%s', '%s', '%s'],
             ['%d']
         );
     }
@@ -166,10 +167,10 @@ class WordPressQueueRepository implements QueueRepositoryInterface
         $wpdb->query(
             $wpdb->prepare(
                 "UPDATE {$this->table}
-                 SET status = %s, last_error = %s, attempts = attempts + 1
+                 SET status = %s, last_error = %s, claim_token = '', attempts = attempts + 1
                  WHERE id = %d",
                 JobStatus::Failed->value,
-                JobFactory::truncateError($errorMessage),
+                JobFactory::sanitizeError($errorMessage),
                 $jobId
             )
         );

--- a/src/Queue/Infrastructure/WordPressQueueRepository.php
+++ b/src/Queue/Infrastructure/WordPressQueueRepository.php
@@ -36,19 +36,24 @@ class WordPressQueueRepository implements QueueRepositoryInterface
             job_key VARCHAR(255) NOT NULL,
             job_group VARCHAR(255) NOT NULL DEFAULT 'default',
             payload LONGTEXT NOT NULL DEFAULT '[]',
+            payload_hash CHAR(32) NOT NULL DEFAULT '',
             status VARCHAR(20) NOT NULL DEFAULT 'pending',
             attempts INT UNSIGNED NOT NULL DEFAULT 0,
             max_retries INT UNSIGNED NOT NULL DEFAULT 3,
             last_error TEXT NOT NULL DEFAULT '',
+            claim_token VARCHAR(64) NOT NULL DEFAULT '',
             interval_seconds INT UNSIGNED NOT NULL DEFAULT 0,
             scheduled_at DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
             claimed_at DATETIME DEFAULT NULL,
             completed_at DATETIME DEFAULT NULL,
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             PRIMARY KEY (id),
             KEY idx_status_group_scheduled (status, job_group, scheduled_at),
             KEY idx_job_key_status (job_key, status),
-            KEY idx_status_claimed (status, claimed_at)
+            KEY idx_status_claimed (status, claimed_at),
+            KEY idx_payload_hash (job_key, payload_hash, status),
+            KEY idx_status_completed (status, completed_at)
         ) {$charset};";
 
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
@@ -67,12 +72,16 @@ class WordPressQueueRepository implements QueueRepositoryInterface
     {
         global $wpdb;
 
+        $payloadJson = \wp_json_encode($job->getPayload()) ?: '[]';
+        $payloadHash = $job->getPayloadHash() ?: \md5($payloadJson);
+
         $wpdb->insert(
             $this->table,
             [
                 'job_key' => $job->getKey(),
                 'job_group' => $job->getGroup(),
-                'payload' => \wp_json_encode($job->getPayload()),
+                'payload' => $payloadJson,
+                'payload_hash' => $payloadHash,
                 'status' => $job->getStatus()->value,
                 'attempts' => $job->getAttempts(),
                 'max_retries' => $job->getMaxRetries(),
@@ -80,7 +89,7 @@ class WordPressQueueRepository implements QueueRepositoryInterface
                 'scheduled_at' => $job->getScheduledAt()?->format('Y-m-d H:i:s') ?? \gmdate('Y-m-d H:i:s'),
                 'created_at' => $job->getCreatedAt()?->format('Y-m-d H:i:s') ?? \gmdate('Y-m-d H:i:s'),
             ],
-            ['%s', '%s', '%s', '%s', '%d', '%d', '%d', '%s', '%s']
+            ['%s', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%s', '%s']
         );
 
         return (int) $wpdb->insert_id;
@@ -91,12 +100,14 @@ class WordPressQueueRepository implements QueueRepositoryInterface
         global $wpdb;
 
         $now = \gmdate('Y-m-d H:i:s');
+        $claimToken = \bin2hex(\random_bytes(16));
 
         // Atomic claim: UPDATE with WHERE ensures only one worker gets the job.
+        // The unique claim_token prevents ambiguity when retrieving the claimed job.
         $updated = $wpdb->query(
             $wpdb->prepare(
                 "UPDATE {$this->table}
-                 SET status = %s, claimed_at = %s
+                 SET status = %s, claimed_at = %s, claim_token = %s
                  WHERE status = %s
                    AND job_group = %s
                    AND scheduled_at <= %s
@@ -104,6 +115,7 @@ class WordPressQueueRepository implements QueueRepositoryInterface
                  LIMIT 1",
                 JobStatus::Running->value,
                 $now,
+                $claimToken,
                 JobStatus::Pending->value,
                 $group,
                 $now
@@ -114,14 +126,11 @@ class WordPressQueueRepository implements QueueRepositoryInterface
             return null;
         }
 
+        // Retrieve by unique claim_token — no ambiguity even with concurrent workers.
         $row = $wpdb->get_row(
             $wpdb->prepare(
-                "SELECT * FROM {$this->table}
-                 WHERE status = %s AND job_group = %s AND claimed_at = %s
-                 ORDER BY id DESC LIMIT 1",
-                JobStatus::Running->value,
-                $group,
-                $now
+                "SELECT * FROM {$this->table} WHERE claim_token = %s LIMIT 1",
+                $claimToken
             ),
             ARRAY_A
         );
@@ -160,7 +169,7 @@ class WordPressQueueRepository implements QueueRepositoryInterface
                  SET status = %s, last_error = %s, attempts = attempts + 1
                  WHERE id = %d",
                 JobStatus::Failed->value,
-                $errorMessage,
+                JobFactory::truncateError($errorMessage),
                 $jobId
             )
         );
@@ -175,9 +184,10 @@ class WordPressQueueRepository implements QueueRepositoryInterface
             [
                 'status' => JobStatus::Pending->value,
                 'claimed_at' => null,
+                'claim_token' => '',
             ],
             ['id' => $jobId],
-            ['%s', null],
+            ['%s', null, '%s'],
             ['%d']
         );
     }
@@ -247,6 +257,22 @@ class WordPressQueueRepository implements QueueRepositoryInterface
         );
     }
 
+    public function cleanupFailed(int $olderThanSeconds = 604800): int
+    {
+        global $wpdb;
+
+        $cutoff = \gmdate('Y-m-d H:i:s', \time() - $olderThanSeconds);
+
+        return (int) $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$this->table}
+                 WHERE status = %s AND attempts >= max_retries AND updated_at < %s",
+                JobStatus::Failed->value,
+                $cutoff
+            )
+        );
+    }
+
     public function cancel(int $jobId): void
     {
         global $wpdb;
@@ -269,7 +295,7 @@ class WordPressQueueRepository implements QueueRepositoryInterface
         return (int) $wpdb->query(
             $wpdb->prepare(
                 "UPDATE {$this->table}
-                 SET status = %s, claimed_at = NULL
+                 SET status = %s, claimed_at = NULL, claim_token = ''
                  WHERE status = %s AND claimed_at < %s",
                 JobStatus::Pending->value,
                 JobStatus::Running->value,
@@ -278,23 +304,42 @@ class WordPressQueueRepository implements QueueRepositoryInterface
         );
     }
 
-    /**
-     * Check if a pending job with the given key and payload already exists.
-     */
-    public function hasPendingDuplicate(string $jobKey, string $payloadJson): bool
+    public function hasPendingDuplicate(string $jobKey, string $payloadHash): bool
     {
         global $wpdb;
 
         $count = (int) $wpdb->get_var(
             $wpdb->prepare(
                 "SELECT COUNT(*) FROM {$this->table}
-                 WHERE job_key = %s AND payload = %s AND status = %s",
+                 WHERE job_key = %s AND payload_hash = %s AND status = %s",
                 $jobKey,
-                $payloadJson,
+                $payloadHash,
                 JobStatus::Pending->value
             )
         );
 
         return $count > 0;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getActiveGroups(): array
+    {
+        global $wpdb;
+
+        $groups = $wpdb->get_col(
+            $wpdb->prepare(
+                "SELECT DISTINCT job_group FROM {$this->table} WHERE status IN (%s, %s)",
+                JobStatus::Pending->value,
+                JobStatus::Running->value
+            )
+        );
+
+        if (!\is_array($groups)) {
+            return [];
+        }
+
+        return $groups;
     }
 }

--- a/src/Queue/QueueDispatcher.php
+++ b/src/Queue/QueueDispatcher.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue;
+
+use BackTo\Framework\Queue\Contracts\QueueDispatcherInterface;
+use BackTo\Framework\Queue\Contracts\QueueRepositoryInterface;
+use BackTo\Framework\Queue\Factory\JobFactory;
+use BackTo\Framework\Queue\Infrastructure\WordPressQueueRepository;
+
+class QueueDispatcher implements QueueDispatcherInterface
+{
+    private QueueRepositoryInterface $repository;
+    private QueueRegistry $registry;
+    private JobFactory $factory;
+
+    public function __construct(
+        QueueRepositoryInterface $repository,
+        QueueRegistry $registry,
+        JobFactory $factory
+    ) {
+        $this->repository = $repository;
+        $this->registry = $registry;
+        $this->factory = $factory;
+    }
+
+    public function dispatch(string $jobKey, array $payload = [], int $delay = 0, string $group = 'default'): int
+    {
+        $handler = $this->registry->get($jobKey);
+        $maxRetries = $handler !== null ? $handler->getMaxRetries() : 3;
+
+        $job = $this->factory->create($jobKey, $payload, $group, $maxRetries, $delay);
+
+        return $this->repository->enqueue($job);
+    }
+
+    public function dispatchUnique(string $jobKey, array $payload = [], int $delay = 0, string $group = 'default'): ?int
+    {
+        $payloadJson = \wp_json_encode($payload) ?: '[]';
+
+        if ($this->repository instanceof WordPressQueueRepository && $this->repository->hasPendingDuplicate($jobKey, $payloadJson)) {
+            return null;
+        }
+
+        return $this->dispatch($jobKey, $payload, $delay, $group);
+    }
+
+    public function schedule(string $jobKey, int $intervalSeconds, array $payload = [], string $group = 'default'): int
+    {
+        $handler = $this->registry->get($jobKey);
+        $maxRetries = $handler !== null ? $handler->getMaxRetries() : 3;
+
+        $job = $this->factory->create($jobKey, $payload, $group, $maxRetries, 0, $intervalSeconds);
+
+        return $this->repository->enqueue($job);
+    }
+}

--- a/src/Queue/QueueDispatcher.php
+++ b/src/Queue/QueueDispatcher.php
@@ -7,7 +7,6 @@ namespace BackTo\Framework\Queue;
 use BackTo\Framework\Queue\Contracts\QueueDispatcherInterface;
 use BackTo\Framework\Queue\Contracts\QueueRepositoryInterface;
 use BackTo\Framework\Queue\Factory\JobFactory;
-use BackTo\Framework\Queue\Infrastructure\WordPressQueueRepository;
 
 class QueueDispatcher implements QueueDispatcherInterface
 {
@@ -37,9 +36,10 @@ class QueueDispatcher implements QueueDispatcherInterface
 
     public function dispatchUnique(string $jobKey, array $payload = [], int $delay = 0, string $group = 'default'): ?int
     {
-        $payloadJson = \wp_json_encode($payload) ?: '[]';
+        $payloadJson = \json_encode($payload, \JSON_THROW_ON_ERROR);
+        $payloadHash = \md5($payloadJson);
 
-        if ($this->repository instanceof WordPressQueueRepository && $this->repository->hasPendingDuplicate($jobKey, $payloadJson)) {
+        if ($this->repository->hasPendingDuplicate($jobKey, $payloadHash)) {
             return null;
         }
 

--- a/src/Queue/QueueExtension.php
+++ b/src/Queue/QueueExtension.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue;
+
+use BackTo\Framework\Contracts\ExtensionInterface;
+use BackTo\Framework\Queue\Contracts\JobInterface;
+use BackTo\Framework\Queue\Contracts\QueueDispatcherInterface;
+use BackTo\Framework\Queue\Contracts\QueueRepositoryInterface;
+use BackTo\Framework\Queue\DependencyInjection\Compiler\RegisterQueuePass;
+use BackTo\Framework\Queue\Infrastructure\WordPressQueueRepository;
+use BackToVendor\Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class QueueExtension implements ExtensionInterface
+{
+    public function getBundle(): ?array
+    {
+        return [
+            'dir' => __DIR__,
+            'namespace' => 'BackTo\\Framework\\Queue\\',
+            'exclude' => '{DependencyInjection,Entity,Tests,Contracts,Infrastructure}',
+        ];
+    }
+
+    public function register(ContainerBuilder $containerBuilder): void
+    {
+        $containerBuilder->registerForAutoconfiguration(JobInterface::class)
+            ->addTag('wordpress.queue_job');
+
+        $containerBuilder->addCompilerPass(new RegisterQueuePass());
+
+        $containerBuilder->register(QueueRepositoryInterface::class, WordPressQueueRepository::class)
+            ->setAutowired(true);
+        $containerBuilder->setAlias(WordPressQueueRepository::class, QueueRepositoryInterface::class);
+
+        $containerBuilder->register(QueueDispatcherInterface::class, QueueDispatcher::class)
+            ->setAutowired(true);
+        $containerBuilder->setAlias(QueueDispatcher::class, QueueDispatcherInterface::class)
+            ->setPublic(true);
+    }
+
+    public function getDefaultConfiguration(): array
+    {
+        return [
+            'framework.queue.batch_size' => 10,
+            'framework.queue.rescue_timeout' => 300,
+            'framework.queue.cleanup_age' => 86400,
+        ];
+    }
+}

--- a/src/Queue/QueueRegistry.php
+++ b/src/Queue/QueueRegistry.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue;
+
+use BackTo\Framework\Contracts\RegistryInterface;
+use BackTo\Framework\Queue\Contracts\JobInterface;
+use BackTo\Framework\Queue\Contracts\QueueRegistryInterface;
+
+class QueueRegistry implements RegistryInterface, QueueRegistryInterface
+{
+    /** @var array<string, JobInterface> */
+    private array $jobs = [];
+
+    public function add(JobInterface $job): QueueRegistryInterface
+    {
+        $this->jobs[$job->getKey()] = $job;
+
+        return $this;
+    }
+
+    /**
+     * @return JobInterface[]
+     */
+    public function getJobs(): array
+    {
+        return \array_values($this->jobs);
+    }
+
+    public function get(string $key): ?JobInterface
+    {
+        return $this->jobs[$key] ?? null;
+    }
+}

--- a/src/Queue/QueueWorker.php
+++ b/src/Queue/QueueWorker.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue;
+
+use BackTo\Framework\Queue\Contracts\QueueRepositoryInterface;
+use BackTo\Framework\Queue\Entity\Job;
+use BackTo\Framework\Queue\Factory\JobFactory;
+
+/**
+ * Processes jobs from the queue.
+ *
+ * The worker claims pending jobs, executes their handlers,
+ * manages retries, and handles recurring job rescheduling.
+ */
+class QueueWorker
+{
+    private QueueRepositoryInterface $repository;
+    private QueueRegistry $registry;
+    private JobFactory $factory;
+
+    public function __construct(
+        QueueRepositoryInterface $repository,
+        QueueRegistry $registry,
+        JobFactory $factory
+    ) {
+        $this->repository = $repository;
+        $this->registry = $registry;
+        $this->factory = $factory;
+    }
+
+    /**
+     * Process a batch of jobs from the queue.
+     *
+     * @param string $group The queue group to process.
+     * @param int $batchSize Maximum number of jobs to process in this run.
+     *
+     * @return int Number of jobs processed.
+     */
+    public function processQueue(string $group = 'default', int $batchSize = 10): int
+    {
+        $processed = 0;
+
+        for ($i = 0; $i < $batchSize; $i++) {
+            $job = $this->repository->claimNextPending($group);
+
+            if ($job === null) {
+                break;
+            }
+
+            $this->processJob($job);
+            $processed++;
+        }
+
+        return $processed;
+    }
+
+    /**
+     * Process a single claimed job.
+     */
+    private function processJob(Job $job): void
+    {
+        $handler = $this->registry->get($job->getKey());
+
+        if ($handler === null) {
+            $this->repository->markFailed($job->getId(), "No handler registered for job key: {$job->getKey()}");
+
+            return;
+        }
+
+        try {
+            $handler->handle($job->getPayload());
+            $this->repository->markCompleted($job->getId());
+
+            if ($job->isRecurring()) {
+                $this->rescheduleRecurring($job);
+            }
+        } catch (\Throwable $e) {
+            $this->handleFailure($job, $e);
+        }
+    }
+
+    /**
+     * Handle a job failure with retry logic.
+     */
+    private function handleFailure(Job $job, \Throwable $exception): void
+    {
+        $this->repository->markFailed($job->getId(), $exception->getMessage());
+
+        // Refresh to get updated attempts count.
+        $updatedJob = $this->repository->find($job->getId());
+
+        if ($updatedJob !== null && $updatedJob->canRetry()) {
+            $this->repository->release($job->getId());
+        }
+    }
+
+    /**
+     * Reschedule a recurring job for its next execution.
+     */
+    private function rescheduleRecurring(Job $job): void
+    {
+        $nextJob = $this->factory->create(
+            $job->getKey(),
+            $job->getPayload(),
+            $job->getGroup(),
+            $job->getMaxRetries(),
+            $job->getIntervalSeconds(),
+            $job->getIntervalSeconds()
+        );
+
+        $this->repository->enqueue($nextJob);
+    }
+}

--- a/src/Queue/QueueWorker.php
+++ b/src/Queue/QueueWorker.php
@@ -16,6 +16,8 @@ use BackTo\Framework\Queue\Factory\JobFactory;
  */
 class QueueWorker
 {
+    private const MAX_BATCH_SIZE = 100;
+
     private QueueRepositoryInterface $repository;
     private QueueRegistry $registry;
     private JobFactory $factory;
@@ -34,12 +36,13 @@ class QueueWorker
      * Process a batch of jobs from the queue.
      *
      * @param string $group The queue group to process.
-     * @param int $batchSize Maximum number of jobs to process in this run.
+     * @param int $batchSize Maximum number of jobs to process in this run (capped at 100).
      *
      * @return int Number of jobs processed.
      */
     public function processQueue(string $group = 'default', int $batchSize = 10): int
     {
+        $batchSize = \min(\max($batchSize, 1), self::MAX_BATCH_SIZE);
         $processed = 0;
 
         for ($i = 0; $i < $batchSize; $i++) {

--- a/src/Queue/RegisterQueue.php
+++ b/src/Queue/RegisterQueue.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue;
+
+use BackTo\Framework\Contracts\ActivationHooks;
+use BackTo\Framework\Contracts\DeactivationHooks;
+use BackTo\Framework\Contracts\HookDispatcherInterface;
+use BackTo\Framework\Contracts\Hooks;
+use BackTo\Framework\Queue\Contracts\QueueRepositoryInterface;
+
+/**
+ * Orchestrates the queue system lifecycle and cron-based processing.
+ *
+ * - Creates the jobs table on activation.
+ * - Drops the table on deactivation.
+ * - Registers a WP-Cron event to process jobs periodically.
+ * - Rescues stuck jobs on each cron tick.
+ */
+class RegisterQueue implements Hooks, ActivationHooks, DeactivationHooks
+{
+    private const CRON_HOOK = 'backto_queue_process';
+    private const RESCUE_HOOK = 'backto_queue_rescue';
+    private const CLEANUP_HOOK = 'backto_queue_cleanup';
+    private const SCHEDULE_INTERVAL = 'every_minute';
+
+    private QueueRepositoryInterface $repository;
+    private QueueWorker $worker;
+    private QueueRegistry $registry;
+    private HookDispatcherInterface $hookDispatcher;
+
+    public function __construct(
+        QueueRepositoryInterface $repository,
+        QueueWorker $worker,
+        QueueRegistry $registry,
+        HookDispatcherInterface $hookDispatcher
+    ) {
+        $this->repository = $repository;
+        $this->worker = $worker;
+        $this->registry = $registry;
+        $this->hookDispatcher = $hookDispatcher;
+    }
+
+    public function activate(): void
+    {
+        $this->repository->createTable();
+        $this->scheduleCronEvents();
+    }
+
+    public function deactivate(): void
+    {
+        $this->unscheduleCronEvents();
+    }
+
+    public function hooks(): void
+    {
+        $this->hookDispatcher->addFilter('cron_schedules', [$this, 'registerCronSchedule']);
+        $this->hookDispatcher->addAction('init', [$this, 'ensureCronScheduled']);
+        $this->hookDispatcher->addAction(self::CRON_HOOK, [$this, 'processAllGroups']);
+        $this->hookDispatcher->addAction(self::RESCUE_HOOK, [$this, 'rescueStuckJobs']);
+        $this->hookDispatcher->addAction(self::CLEANUP_HOOK, [$this, 'cleanupCompletedJobs']);
+    }
+
+    /**
+     * Register the "every minute" cron schedule.
+     *
+     * @param array<string, array{interval: int, display: string}> $schedules
+     *
+     * @return array<string, array{interval: int, display: string}>
+     */
+    public function registerCronSchedule(array $schedules): array
+    {
+        if (!isset($schedules[self::SCHEDULE_INTERVAL])) {
+            $schedules[self::SCHEDULE_INTERVAL] = [
+                'interval' => 60,
+                'display' => 'Every Minute',
+            ];
+        }
+
+        return $schedules;
+    }
+
+    /**
+     * Ensure cron events are scheduled (idempotent).
+     */
+    public function ensureCronScheduled(): void
+    {
+        if (!\wp_next_scheduled(self::CRON_HOOK)) {
+            \wp_schedule_event(\time(), self::SCHEDULE_INTERVAL, self::CRON_HOOK);
+        }
+
+        if (!\wp_next_scheduled(self::RESCUE_HOOK)) {
+            \wp_schedule_event(\time(), 'hourly', self::RESCUE_HOOK);
+        }
+
+        if (!\wp_next_scheduled(self::CLEANUP_HOOK)) {
+            \wp_schedule_event(\time(), 'daily', self::CLEANUP_HOOK);
+        }
+    }
+
+    /**
+     * Process all registered queue groups.
+     */
+    public function processAllGroups(): void
+    {
+        $groups = $this->collectGroups();
+
+        foreach ($groups as $group) {
+            $this->worker->processQueue($group);
+        }
+    }
+
+    /**
+     * Rescue jobs stuck in running state.
+     */
+    public function rescueStuckJobs(): void
+    {
+        $this->repository->rescueStuck(300);
+    }
+
+    /**
+     * Clean up completed jobs older than 24 hours.
+     */
+    public function cleanupCompletedJobs(): void
+    {
+        $this->repository->cleanup(86400);
+    }
+
+    /**
+     * Collect all unique groups from registered job handlers.
+     *
+     * @return string[]
+     */
+    private function collectGroups(): array
+    {
+        $groups = ['default'];
+
+        foreach ($this->registry->getJobs() as $job) {
+            $group = $job->getGroup();
+            if (!\in_array($group, $groups, true)) {
+                $groups[] = $group;
+            }
+        }
+
+        return $groups;
+    }
+
+    private function scheduleCronEvents(): void
+    {
+        if (!\wp_next_scheduled(self::CRON_HOOK)) {
+            \wp_schedule_event(\time(), self::SCHEDULE_INTERVAL, self::CRON_HOOK);
+        }
+
+        if (!\wp_next_scheduled(self::RESCUE_HOOK)) {
+            \wp_schedule_event(\time(), 'hourly', self::RESCUE_HOOK);
+        }
+
+        if (!\wp_next_scheduled(self::CLEANUP_HOOK)) {
+            \wp_schedule_event(\time(), 'daily', self::CLEANUP_HOOK);
+        }
+    }
+
+    private function unscheduleCronEvents(): void
+    {
+        \wp_clear_scheduled_hook(self::CRON_HOOK);
+        \wp_clear_scheduled_hook(self::RESCUE_HOOK);
+        \wp_clear_scheduled_hook(self::CLEANUP_HOOK);
+    }
+}

--- a/src/Queue/RegisterQueue.php
+++ b/src/Queue/RegisterQueue.php
@@ -54,6 +54,18 @@ class RegisterQueue implements Hooks, ActivationHooks, DeactivationHooks
         $this->unscheduleCronEvents();
     }
 
+    /**
+     * Clean up all queue data on plugin uninstall.
+     *
+     * Call this from your uninstall.php or register_uninstall_hook callback
+     * to remove the jobs table and any transients created by the queue.
+     */
+    public function uninstall(): void
+    {
+        $this->repository->dropTable();
+        \delete_transient(self::LOCK_KEY);
+    }
+
     public function hooks(): void
     {
         $this->hookDispatcher->addFilter('cron_schedules', [$this, 'registerCronSchedule']);

--- a/src/Queue/RegisterQueue.php
+++ b/src/Queue/RegisterQueue.php
@@ -14,9 +14,8 @@ use BackTo\Framework\Queue\Contracts\QueueRepositoryInterface;
  * Orchestrates the queue system lifecycle and cron-based processing.
  *
  * - Creates the jobs table on activation.
- * - Drops the table on deactivation.
- * - Registers a WP-Cron event to process jobs periodically.
- * - Rescues stuck jobs on each cron tick.
+ * - Registers WP-Cron events to process, rescue, and cleanup jobs.
+ * - Uses a transient-based lock to prevent concurrent cron execution.
  */
 class RegisterQueue implements Hooks, ActivationHooks, DeactivationHooks
 {
@@ -24,6 +23,8 @@ class RegisterQueue implements Hooks, ActivationHooks, DeactivationHooks
     private const RESCUE_HOOK = 'backto_queue_rescue';
     private const CLEANUP_HOOK = 'backto_queue_cleanup';
     private const SCHEDULE_INTERVAL = 'every_minute';
+    private const LOCK_KEY = 'backto_queue_lock';
+    private const LOCK_TIMEOUT = 300;
 
     private QueueRepositoryInterface $repository;
     private QueueWorker $worker;
@@ -59,7 +60,7 @@ class RegisterQueue implements Hooks, ActivationHooks, DeactivationHooks
         $this->hookDispatcher->addAction('init', [$this, 'ensureCronScheduled']);
         $this->hookDispatcher->addAction(self::CRON_HOOK, [$this, 'processAllGroups']);
         $this->hookDispatcher->addAction(self::RESCUE_HOOK, [$this, 'rescueStuckJobs']);
-        $this->hookDispatcher->addAction(self::CLEANUP_HOOK, [$this, 'cleanupCompletedJobs']);
+        $this->hookDispatcher->addAction(self::CLEANUP_HOOK, [$this, 'cleanupJobs']);
     }
 
     /**
@@ -100,14 +101,22 @@ class RegisterQueue implements Hooks, ActivationHooks, DeactivationHooks
     }
 
     /**
-     * Process all registered queue groups.
+     * Process all queue groups with a transient-based lock to prevent overlap.
      */
     public function processAllGroups(): void
     {
-        $groups = $this->collectGroups();
+        if (!$this->acquireLock()) {
+            return;
+        }
 
-        foreach ($groups as $group) {
-            $this->worker->processQueue($group);
+        try {
+            $groups = $this->collectGroups();
+
+            foreach ($groups as $group) {
+                $this->worker->processQueue($group);
+            }
+        } finally {
+            $this->releaseLock();
         }
     }
 
@@ -120,15 +129,16 @@ class RegisterQueue implements Hooks, ActivationHooks, DeactivationHooks
     }
 
     /**
-     * Clean up completed jobs older than 24 hours.
+     * Clean up completed jobs (>24h) and exhausted failed jobs (>7 days).
      */
-    public function cleanupCompletedJobs(): void
+    public function cleanupJobs(): void
     {
         $this->repository->cleanup(86400);
+        $this->repository->cleanupFailed(604800);
     }
 
     /**
-     * Collect all unique groups from registered job handlers.
+     * Collect all unique groups from registered handlers AND active DB jobs.
      *
      * @return string[]
      */
@@ -138,6 +148,12 @@ class RegisterQueue implements Hooks, ActivationHooks, DeactivationHooks
 
         foreach ($this->registry->getJobs() as $job) {
             $group = $job->getGroup();
+            if (!\in_array($group, $groups, true)) {
+                $groups[] = $group;
+            }
+        }
+
+        foreach ($this->repository->getActiveGroups() as $group) {
             if (!\in_array($group, $groups, true)) {
                 $groups[] = $group;
             }
@@ -166,5 +182,21 @@ class RegisterQueue implements Hooks, ActivationHooks, DeactivationHooks
         \wp_clear_scheduled_hook(self::CRON_HOOK);
         \wp_clear_scheduled_hook(self::RESCUE_HOOK);
         \wp_clear_scheduled_hook(self::CLEANUP_HOOK);
+    }
+
+    protected function acquireLock(): bool
+    {
+        if (\get_transient(self::LOCK_KEY)) {
+            return false;
+        }
+
+        \set_transient(self::LOCK_KEY, \getmypid() ?: 1, self::LOCK_TIMEOUT);
+
+        return true;
+    }
+
+    protected function releaseLock(): void
+    {
+        \delete_transient(self::LOCK_KEY);
     }
 }

--- a/src/Queue/Tests/JobFactoryTest.php
+++ b/src/Queue/Tests/JobFactoryTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Tests;
+
+use BackTo\Framework\Exception\FrameworkException;
+use BackTo\Framework\Queue\Entity\Job;
+use BackTo\Framework\Queue\Entity\JobStatus;
+use BackTo\Framework\Queue\Factory\JobFactory;
+use PHPUnit\Framework\TestCase;
+
+class JobFactoryTest extends TestCase
+{
+    private JobFactory $factory;
+
+    protected function setUp(): void
+    {
+        $this->factory = new JobFactory();
+    }
+
+    public function testCreateJobWithDefaults(): void
+    {
+        $job = $this->factory->create('send_email');
+
+        $this->assertSame('send_email', $job->getKey());
+        $this->assertSame('default', $job->getGroup());
+        $this->assertSame([], $job->getPayload());
+        $this->assertSame(JobStatus::Pending, $job->getStatus());
+        $this->assertSame(0, $job->getAttempts());
+        $this->assertSame(3, $job->getMaxRetries());
+        $this->assertSame(0, $job->getIntervalSeconds());
+        $this->assertNotNull($job->getScheduledAt());
+        $this->assertNotNull($job->getCreatedAt());
+    }
+
+    public function testCreateJobWithCustomParams(): void
+    {
+        $payload = ['to' => 'test@example.com', 'subject' => 'Hello'];
+
+        $job = $this->factory->create(
+            'send_email',
+            $payload,
+            'emails',
+            5,
+            60,
+            3600
+        );
+
+        $this->assertSame('send_email', $job->getKey());
+        $this->assertSame('emails', $job->getGroup());
+        $this->assertSame($payload, $job->getPayload());
+        $this->assertSame(5, $job->getMaxRetries());
+        $this->assertSame(3600, $job->getIntervalSeconds());
+        $this->assertTrue($job->isRecurring());
+    }
+
+    public function testCreateJobWithDelay(): void
+    {
+        $before = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $job = $this->factory->create('send_email', [], 'default', 3, 120);
+        $expectedMin = $before->modify('+120 seconds');
+
+        $this->assertNotNull($job->getScheduledAt());
+        $this->assertGreaterThanOrEqual($expectedMin, $job->getScheduledAt());
+    }
+
+    public function testCreateJobWithEmptyKeyThrows(): void
+    {
+        $this->expectException(FrameworkException::class);
+        $this->expectExceptionMessage('Job key cannot be empty.');
+
+        $this->factory->create('');
+    }
+
+    public function testFromRowHydration(): void
+    {
+        $row = [
+            'id' => '42',
+            'job_key' => 'process_image',
+            'job_group' => 'media',
+            'payload' => '{"url":"https://example.com/image.jpg"}',
+            'status' => 'running',
+            'attempts' => '1',
+            'max_retries' => '5',
+            'last_error' => 'Timeout',
+            'interval_seconds' => '0',
+            'scheduled_at' => '2025-01-15 10:30:00',
+            'claimed_at' => '2025-01-15 10:31:00',
+            'completed_at' => '0000-00-00 00:00:00',
+            'created_at' => '2025-01-15 10:00:00',
+        ];
+
+        $job = $this->factory->fromRow($row);
+
+        $this->assertSame(42, $job->getId());
+        $this->assertSame('process_image', $job->getKey());
+        $this->assertSame('media', $job->getGroup());
+        $this->assertSame(['url' => 'https://example.com/image.jpg'], $job->getPayload());
+        $this->assertSame(JobStatus::Running, $job->getStatus());
+        $this->assertSame(1, $job->getAttempts());
+        $this->assertSame(5, $job->getMaxRetries());
+        $this->assertSame('Timeout', $job->getLastError());
+        $this->assertNotNull($job->getScheduledAt());
+        $this->assertNotNull($job->getClaimedAt());
+        $this->assertNull($job->getCompletedAt());
+        $this->assertNotNull($job->getCreatedAt());
+        $this->assertFalse($job->isRecurring());
+    }
+
+    public function testFromRowWithEmptyPayload(): void
+    {
+        $row = [
+            'id' => '1',
+            'job_key' => 'cleanup',
+            'payload' => '',
+        ];
+
+        $job = $this->factory->fromRow($row);
+
+        $this->assertSame([], $job->getPayload());
+    }
+
+    public function testFromRowWithInvalidStatus(): void
+    {
+        $row = [
+            'id' => '1',
+            'job_key' => 'test',
+            'status' => 'invalid_status',
+        ];
+
+        $job = $this->factory->fromRow($row);
+
+        $this->assertSame(JobStatus::Pending, $job->getStatus());
+    }
+}

--- a/src/Queue/Tests/JobFactoryTest.php
+++ b/src/Queue/Tests/JobFactoryTest.php
@@ -193,6 +193,73 @@ class JobFactoryTest extends TestCase
         $this->assertSame(JobStatus::Pending, $job->getStatus());
     }
 
+    public function testCreateJobWithPayloadTooLargeThrows(): void
+    {
+        $this->expectException(FrameworkException::class);
+        $this->expectExceptionMessage('Job payload exceeds maximum size');
+
+        // 1 MB + 1 byte payload.
+        $largePayload = ['data' => \str_repeat('x', 1048577)];
+        $this->factory->create('send_email', $largePayload);
+    }
+
+    public function testCreateJobWithPayloadAtLimitSucceeds(): void
+    {
+        // Just under 1 MB — should not throw.
+        $payload = ['data' => \str_repeat('x', 1000000)];
+        $job = $this->factory->create('send_email', $payload);
+
+        $this->assertSame('send_email', $job->getKey());
+    }
+
+    public function testSanitizeErrorStripsFilePaths(): void
+    {
+        $message = 'Error in /home/user/app/src/Service/PaymentGateway.php on line 42';
+        $sanitized = JobFactory::sanitizeError($message);
+
+        $this->assertStringNotContainsString('/home/user/app', $sanitized);
+        $this->assertStringContainsString('[path]', $sanitized);
+        $this->assertStringContainsString('on line 42', $sanitized);
+    }
+
+    public function testSanitizeErrorStripsConnectionStrings(): void
+    {
+        $message = 'Connection failed: mysql://admin:s3cret@db.example.com:3306/mydb';
+        $sanitized = JobFactory::sanitizeError($message);
+
+        $this->assertStringNotContainsString('s3cret', $sanitized);
+        $this->assertStringNotContainsString('db.example.com', $sanitized);
+        $this->assertStringContainsString('[redacted-dsn]', $sanitized);
+    }
+
+    public function testSanitizeErrorStripsLongTokens(): void
+    {
+        $token = \str_repeat('a', 40);
+        $message = "Authorization failed with token {$token} for user";
+        $sanitized = JobFactory::sanitizeError($message);
+
+        $this->assertStringNotContainsString($token, $sanitized);
+        $this->assertStringContainsString('[redacted]', $sanitized);
+    }
+
+    public function testSanitizeErrorPreservesShortMessages(): void
+    {
+        $message = 'Connection timeout after 30s';
+        $sanitized = JobFactory::sanitizeError($message);
+
+        $this->assertSame($message, $sanitized);
+    }
+
+    public function testSanitizeErrorTruncatesLongMessages(): void
+    {
+        // Use a message with spaces to avoid token-redaction patterns.
+        $message = \implode(' ', \array_fill(0, 1500, 'error occurred'));
+        $sanitized = JobFactory::sanitizeError($message);
+
+        $this->assertLessThanOrEqual(5000, \strlen($sanitized));
+        $this->assertStringEndsWith(' [truncated]', $sanitized);
+    }
+
     public function testTruncateErrorShortMessage(): void
     {
         $message = 'Short error';

--- a/src/Queue/Tests/JobFactoryTest.php
+++ b/src/Queue/Tests/JobFactoryTest.php
@@ -73,6 +73,59 @@ class JobFactoryTest extends TestCase
         $this->factory->create('');
     }
 
+    public function testCreateJobWithKeyTooLongThrows(): void
+    {
+        $this->expectException(FrameworkException::class);
+        $this->expectExceptionMessage('Job key cannot exceed 255 characters.');
+
+        $this->factory->create(\str_repeat('a', 256));
+    }
+
+    public function testCreateJobWithGroupTooLongThrows(): void
+    {
+        $this->expectException(FrameworkException::class);
+        $this->expectExceptionMessage('Job group cannot exceed 255 characters.');
+
+        $this->factory->create('valid_key', [], \str_repeat('g', 256));
+    }
+
+    public function testCreateJobWithNegativeDelayClampsToZero(): void
+    {
+        $before = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+        $job = $this->factory->create('send_email', [], 'default', 3, -10);
+
+        $this->assertNotNull($job->getScheduledAt());
+        // Should be scheduled at now, not in the past.
+        $this->assertGreaterThanOrEqual($before, $job->getScheduledAt());
+        $this->assertLessThanOrEqual($before->modify('+2 seconds'), $job->getScheduledAt());
+    }
+
+    public function testCreateJobWithNegativeIntervalClampsToZero(): void
+    {
+        $job = $this->factory->create('send_email', [], 'default', 3, 0, -600);
+
+        $this->assertSame(0, $job->getIntervalSeconds());
+        $this->assertFalse($job->isRecurring());
+    }
+
+    public function testCreateJobComputesPayloadHash(): void
+    {
+        $payload = ['to' => 'user@example.com'];
+        $job = $this->factory->create('send_email', $payload);
+
+        $expectedHash = \md5(\json_encode($payload, \JSON_THROW_ON_ERROR));
+        $this->assertSame($expectedHash, $job->getPayloadHash());
+    }
+
+    public function testCreateJobEmptyPayloadHasConsistentHash(): void
+    {
+        $job1 = $this->factory->create('job_a');
+        $job2 = $this->factory->create('job_b');
+
+        $this->assertSame($job1->getPayloadHash(), $job2->getPayloadHash());
+        $this->assertSame(\md5('[]'), $job1->getPayloadHash());
+    }
+
     public function testFromRowHydration(): void
     {
         $row = [
@@ -80,15 +133,18 @@ class JobFactoryTest extends TestCase
             'job_key' => 'process_image',
             'job_group' => 'media',
             'payload' => '{"url":"https://example.com/image.jpg"}',
+            'payload_hash' => 'abc123',
             'status' => 'running',
             'attempts' => '1',
             'max_retries' => '5',
             'last_error' => 'Timeout',
+            'claim_token' => 'token123',
             'interval_seconds' => '0',
             'scheduled_at' => '2025-01-15 10:30:00',
             'claimed_at' => '2025-01-15 10:31:00',
             'completed_at' => '0000-00-00 00:00:00',
             'created_at' => '2025-01-15 10:00:00',
+            'updated_at' => '2025-01-15 10:31:00',
         ];
 
         $job = $this->factory->fromRow($row);
@@ -97,14 +153,17 @@ class JobFactoryTest extends TestCase
         $this->assertSame('process_image', $job->getKey());
         $this->assertSame('media', $job->getGroup());
         $this->assertSame(['url' => 'https://example.com/image.jpg'], $job->getPayload());
+        $this->assertSame('abc123', $job->getPayloadHash());
         $this->assertSame(JobStatus::Running, $job->getStatus());
         $this->assertSame(1, $job->getAttempts());
         $this->assertSame(5, $job->getMaxRetries());
         $this->assertSame('Timeout', $job->getLastError());
+        $this->assertSame('token123', $job->getClaimToken());
         $this->assertNotNull($job->getScheduledAt());
         $this->assertNotNull($job->getClaimedAt());
         $this->assertNull($job->getCompletedAt());
         $this->assertNotNull($job->getCreatedAt());
+        $this->assertNotNull($job->getUpdatedAt());
         $this->assertFalse($job->isRecurring());
     }
 
@@ -132,5 +191,29 @@ class JobFactoryTest extends TestCase
         $job = $this->factory->fromRow($row);
 
         $this->assertSame(JobStatus::Pending, $job->getStatus());
+    }
+
+    public function testTruncateErrorShortMessage(): void
+    {
+        $message = 'Short error';
+
+        $this->assertSame($message, JobFactory::truncateError($message));
+    }
+
+    public function testTruncateErrorLongMessage(): void
+    {
+        $message = \str_repeat('x', 6000);
+
+        $truncated = JobFactory::truncateError($message);
+
+        $this->assertSame(5000, \strlen($truncated));
+        $this->assertStringEndsWith(' [truncated]', $truncated);
+    }
+
+    public function testTruncateErrorExactLimit(): void
+    {
+        $message = \str_repeat('x', 5000);
+
+        $this->assertSame($message, JobFactory::truncateError($message));
     }
 }

--- a/src/Queue/Tests/JobStatusTest.php
+++ b/src/Queue/Tests/JobStatusTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Tests;
+
+use BackTo\Framework\Queue\Entity\JobStatus;
+use PHPUnit\Framework\TestCase;
+
+class JobStatusTest extends TestCase
+{
+    public function testPendingValue(): void
+    {
+        $this->assertSame('pending', JobStatus::Pending->value);
+    }
+
+    public function testRunningValue(): void
+    {
+        $this->assertSame('running', JobStatus::Running->value);
+    }
+
+    public function testCompletedValue(): void
+    {
+        $this->assertSame('completed', JobStatus::Completed->value);
+    }
+
+    public function testFailedValue(): void
+    {
+        $this->assertSame('failed', JobStatus::Failed->value);
+    }
+
+    public function testCancelledValue(): void
+    {
+        $this->assertSame('cancelled', JobStatus::Cancelled->value);
+    }
+
+    public function testTryFromWithValidValue(): void
+    {
+        $this->assertSame(JobStatus::Pending, JobStatus::tryFrom('pending'));
+        $this->assertSame(JobStatus::Running, JobStatus::tryFrom('running'));
+        $this->assertSame(JobStatus::Completed, JobStatus::tryFrom('completed'));
+        $this->assertSame(JobStatus::Failed, JobStatus::tryFrom('failed'));
+        $this->assertSame(JobStatus::Cancelled, JobStatus::tryFrom('cancelled'));
+    }
+
+    public function testTryFromWithInvalidValueReturnsNull(): void
+    {
+        $this->assertNull(JobStatus::tryFrom('unknown'));
+        $this->assertNull(JobStatus::tryFrom(''));
+    }
+
+    public function testAllCasesCount(): void
+    {
+        $this->assertCount(5, JobStatus::cases());
+    }
+}

--- a/src/Queue/Tests/JobTest.php
+++ b/src/Queue/Tests/JobTest.php
@@ -18,10 +18,17 @@ class JobTest extends TestCase
         $this->assertSame('', $job->getKey());
         $this->assertSame('default', $job->getGroup());
         $this->assertSame([], $job->getPayload());
+        $this->assertSame('', $job->getPayloadHash());
         $this->assertSame(JobStatus::Pending, $job->getStatus());
         $this->assertSame(0, $job->getAttempts());
         $this->assertSame(3, $job->getMaxRetries());
         $this->assertSame('', $job->getLastError());
+        $this->assertSame('', $job->getClaimToken());
+        $this->assertNull($job->getScheduledAt());
+        $this->assertNull($job->getClaimedAt());
+        $this->assertNull($job->getCompletedAt());
+        $this->assertNull($job->getCreatedAt());
+        $this->assertNull($job->getUpdatedAt());
         $this->assertSame(0, $job->getIntervalSeconds());
         $this->assertFalse($job->isRecurring());
     }
@@ -29,40 +36,45 @@ class JobTest extends TestCase
     public function testFluentSetters(): void
     {
         $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
-
         $job = new Job();
-        $result = $job->setId(1)
+
+        $result = $job->setId(42)
             ->setKey('send_email')
             ->setGroup('emails')
             ->setPayload(['to' => 'test@example.com'])
+            ->setPayloadHash('abc123')
             ->setStatus(JobStatus::Running)
             ->setAttempts(2)
             ->setMaxRetries(5)
             ->setLastError('Timeout')
+            ->setClaimToken('token-xyz')
             ->setScheduledAt($now)
             ->setClaimedAt($now)
             ->setCompletedAt($now)
             ->setCreatedAt($now)
+            ->setUpdatedAt($now)
             ->setIntervalSeconds(3600);
 
         $this->assertSame($job, $result);
-        $this->assertSame(1, $job->getId());
+        $this->assertSame(42, $job->getId());
         $this->assertSame('send_email', $job->getKey());
         $this->assertSame('emails', $job->getGroup());
         $this->assertSame(['to' => 'test@example.com'], $job->getPayload());
+        $this->assertSame('abc123', $job->getPayloadHash());
         $this->assertSame(JobStatus::Running, $job->getStatus());
         $this->assertSame(2, $job->getAttempts());
         $this->assertSame(5, $job->getMaxRetries());
         $this->assertSame('Timeout', $job->getLastError());
+        $this->assertSame('token-xyz', $job->getClaimToken());
         $this->assertSame($now, $job->getScheduledAt());
         $this->assertSame($now, $job->getClaimedAt());
         $this->assertSame($now, $job->getCompletedAt());
         $this->assertSame($now, $job->getCreatedAt());
+        $this->assertSame($now, $job->getUpdatedAt());
         $this->assertSame(3600, $job->getIntervalSeconds());
-        $this->assertTrue($job->isRecurring());
     }
 
-    public function testIsReadyWhenPendingAndNoSchedule(): void
+    public function testIsReadyWithPendingStatus(): void
     {
         $job = new Job();
         $job->setStatus(JobStatus::Pending);
@@ -70,16 +82,15 @@ class JobTest extends TestCase
         $this->assertTrue($job->isReady());
     }
 
-    public function testIsReadyWhenScheduledInPast(): void
+    public function testIsReadyWithRunningStatus(): void
     {
         $job = new Job();
-        $job->setStatus(JobStatus::Pending)
-            ->setScheduledAt(new \DateTimeImmutable('-1 hour', new \DateTimeZone('UTC')));
+        $job->setStatus(JobStatus::Running);
 
-        $this->assertTrue($job->isReady());
+        $this->assertFalse($job->isReady());
     }
 
-    public function testIsNotReadyWhenScheduledInFuture(): void
+    public function testIsReadyWithFutureScheduledAt(): void
     {
         $job = new Job();
         $job->setStatus(JobStatus::Pending)
@@ -88,23 +99,24 @@ class JobTest extends TestCase
         $this->assertFalse($job->isReady());
     }
 
-    public function testIsNotReadyWhenNotPending(): void
+    public function testIsReadyWithPastScheduledAt(): void
     {
         $job = new Job();
-        $job->setStatus(JobStatus::Running);
+        $job->setStatus(JobStatus::Pending)
+            ->setScheduledAt(new \DateTimeImmutable('-1 hour', new \DateTimeZone('UTC')));
 
-        $this->assertFalse($job->isReady());
+        $this->assertTrue($job->isReady());
     }
 
-    public function testCanRetry(): void
+    public function testCanRetryWithAttemptsRemaining(): void
     {
         $job = new Job();
-        $job->setMaxRetries(3)->setAttempts(2);
+        $job->setMaxRetries(3)->setAttempts(1);
 
         $this->assertTrue($job->canRetry());
     }
 
-    public function testCannotRetryWhenMaxReached(): void
+    public function testCanRetryWithAttemptsExhausted(): void
     {
         $job = new Job();
         $job->setMaxRetries(3)->setAttempts(3);
@@ -112,15 +124,7 @@ class JobTest extends TestCase
         $this->assertFalse($job->canRetry());
     }
 
-    public function testCannotRetryWhenExceeded(): void
-    {
-        $job = new Job();
-        $job->setMaxRetries(2)->setAttempts(5);
-
-        $this->assertFalse($job->canRetry());
-    }
-
-    public function testCannotRetryWhenZeroRetries(): void
+    public function testCanRetryWithZeroMaxRetries(): void
     {
         $job = new Job();
         $job->setMaxRetries(0)->setAttempts(0);
@@ -128,15 +132,23 @@ class JobTest extends TestCase
         $this->assertFalse($job->canRetry());
     }
 
-    public function testIsNotRecurringByDefault(): void
+    public function testIsRecurringWithInterval(): void
     {
         $job = new Job();
+        $job->setIntervalSeconds(3600);
 
-        $this->assertFalse($job->isRecurring());
-        $this->assertSame(0, $job->getIntervalSeconds());
+        $this->assertTrue($job->isRecurring());
     }
 
-    public function testNullDatesBeforeSet(): void
+    public function testIsRecurringWithoutInterval(): void
+    {
+        $job = new Job();
+        $job->setIntervalSeconds(0);
+
+        $this->assertFalse($job->isRecurring());
+    }
+
+    public function testDateGettersReturnNullBeforeSetting(): void
     {
         $job = new Job();
 
@@ -144,38 +156,6 @@ class JobTest extends TestCase
         $this->assertNull($job->getClaimedAt());
         $this->assertNull($job->getCompletedAt());
         $this->assertNull($job->getCreatedAt());
-    }
-
-    public function testIsNotReadyForCompletedStatus(): void
-    {
-        $job = new Job();
-        $job->setStatus(JobStatus::Completed);
-
-        $this->assertFalse($job->isReady());
-    }
-
-    public function testIsNotReadyForFailedStatus(): void
-    {
-        $job = new Job();
-        $job->setStatus(JobStatus::Failed);
-
-        $this->assertFalse($job->isReady());
-    }
-
-    public function testIsNotReadyForCancelledStatus(): void
-    {
-        $job = new Job();
-        $job->setStatus(JobStatus::Cancelled);
-
-        $this->assertFalse($job->isReady());
-    }
-
-    public function testIsReadyWhenScheduledAtExactlyNow(): void
-    {
-        $job = new Job();
-        $job->setStatus(JobStatus::Pending)
-            ->setScheduledAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
-
-        $this->assertTrue($job->isReady());
+        $this->assertNull($job->getUpdatedAt());
     }
 }

--- a/src/Queue/Tests/JobTest.php
+++ b/src/Queue/Tests/JobTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Tests;
+
+use BackTo\Framework\Queue\Entity\Job;
+use BackTo\Framework\Queue\Entity\JobStatus;
+use PHPUnit\Framework\TestCase;
+
+class JobTest extends TestCase
+{
+    public function testDefaultValues(): void
+    {
+        $job = new Job();
+
+        $this->assertSame(0, $job->getId());
+        $this->assertSame('', $job->getKey());
+        $this->assertSame('default', $job->getGroup());
+        $this->assertSame([], $job->getPayload());
+        $this->assertSame(JobStatus::Pending, $job->getStatus());
+        $this->assertSame(0, $job->getAttempts());
+        $this->assertSame(3, $job->getMaxRetries());
+        $this->assertSame('', $job->getLastError());
+        $this->assertSame(0, $job->getIntervalSeconds());
+        $this->assertFalse($job->isRecurring());
+    }
+
+    public function testFluentSetters(): void
+    {
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        $job = new Job();
+        $result = $job->setId(1)
+            ->setKey('send_email')
+            ->setGroup('emails')
+            ->setPayload(['to' => 'test@example.com'])
+            ->setStatus(JobStatus::Running)
+            ->setAttempts(2)
+            ->setMaxRetries(5)
+            ->setLastError('Timeout')
+            ->setScheduledAt($now)
+            ->setClaimedAt($now)
+            ->setCompletedAt($now)
+            ->setCreatedAt($now)
+            ->setIntervalSeconds(3600);
+
+        $this->assertSame($job, $result);
+        $this->assertSame(1, $job->getId());
+        $this->assertSame('send_email', $job->getKey());
+        $this->assertSame('emails', $job->getGroup());
+        $this->assertSame(['to' => 'test@example.com'], $job->getPayload());
+        $this->assertSame(JobStatus::Running, $job->getStatus());
+        $this->assertSame(2, $job->getAttempts());
+        $this->assertSame(5, $job->getMaxRetries());
+        $this->assertSame('Timeout', $job->getLastError());
+        $this->assertSame($now, $job->getScheduledAt());
+        $this->assertSame($now, $job->getClaimedAt());
+        $this->assertSame($now, $job->getCompletedAt());
+        $this->assertSame($now, $job->getCreatedAt());
+        $this->assertSame(3600, $job->getIntervalSeconds());
+        $this->assertTrue($job->isRecurring());
+    }
+
+    public function testIsReadyWhenPendingAndNoSchedule(): void
+    {
+        $job = new Job();
+        $job->setStatus(JobStatus::Pending);
+
+        $this->assertTrue($job->isReady());
+    }
+
+    public function testIsReadyWhenScheduledInPast(): void
+    {
+        $job = new Job();
+        $job->setStatus(JobStatus::Pending)
+            ->setScheduledAt(new \DateTimeImmutable('-1 hour', new \DateTimeZone('UTC')));
+
+        $this->assertTrue($job->isReady());
+    }
+
+    public function testIsNotReadyWhenScheduledInFuture(): void
+    {
+        $job = new Job();
+        $job->setStatus(JobStatus::Pending)
+            ->setScheduledAt(new \DateTimeImmutable('+1 hour', new \DateTimeZone('UTC')));
+
+        $this->assertFalse($job->isReady());
+    }
+
+    public function testIsNotReadyWhenNotPending(): void
+    {
+        $job = new Job();
+        $job->setStatus(JobStatus::Running);
+
+        $this->assertFalse($job->isReady());
+    }
+
+    public function testCanRetry(): void
+    {
+        $job = new Job();
+        $job->setMaxRetries(3)->setAttempts(2);
+
+        $this->assertTrue($job->canRetry());
+    }
+
+    public function testCannotRetryWhenMaxReached(): void
+    {
+        $job = new Job();
+        $job->setMaxRetries(3)->setAttempts(3);
+
+        $this->assertFalse($job->canRetry());
+    }
+}

--- a/src/Queue/Tests/JobTest.php
+++ b/src/Queue/Tests/JobTest.php
@@ -111,4 +111,71 @@ class JobTest extends TestCase
 
         $this->assertFalse($job->canRetry());
     }
+
+    public function testCannotRetryWhenExceeded(): void
+    {
+        $job = new Job();
+        $job->setMaxRetries(2)->setAttempts(5);
+
+        $this->assertFalse($job->canRetry());
+    }
+
+    public function testCannotRetryWhenZeroRetries(): void
+    {
+        $job = new Job();
+        $job->setMaxRetries(0)->setAttempts(0);
+
+        $this->assertFalse($job->canRetry());
+    }
+
+    public function testIsNotRecurringByDefault(): void
+    {
+        $job = new Job();
+
+        $this->assertFalse($job->isRecurring());
+        $this->assertSame(0, $job->getIntervalSeconds());
+    }
+
+    public function testNullDatesBeforeSet(): void
+    {
+        $job = new Job();
+
+        $this->assertNull($job->getScheduledAt());
+        $this->assertNull($job->getClaimedAt());
+        $this->assertNull($job->getCompletedAt());
+        $this->assertNull($job->getCreatedAt());
+    }
+
+    public function testIsNotReadyForCompletedStatus(): void
+    {
+        $job = new Job();
+        $job->setStatus(JobStatus::Completed);
+
+        $this->assertFalse($job->isReady());
+    }
+
+    public function testIsNotReadyForFailedStatus(): void
+    {
+        $job = new Job();
+        $job->setStatus(JobStatus::Failed);
+
+        $this->assertFalse($job->isReady());
+    }
+
+    public function testIsNotReadyForCancelledStatus(): void
+    {
+        $job = new Job();
+        $job->setStatus(JobStatus::Cancelled);
+
+        $this->assertFalse($job->isReady());
+    }
+
+    public function testIsReadyWhenScheduledAtExactlyNow(): void
+    {
+        $job = new Job();
+        $job->setStatus(JobStatus::Pending)
+            ->setScheduledAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
+
+        $this->assertTrue($job->isReady());
+    }
 }

--- a/src/Queue/Tests/QueueDispatcherTest.php
+++ b/src/Queue/Tests/QueueDispatcherTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Tests;
+
+use BackTo\Framework\Queue\Contracts\JobInterface;
+use BackTo\Framework\Queue\Contracts\QueueRepositoryInterface;
+use BackTo\Framework\Queue\Entity\Job;
+use BackTo\Framework\Queue\Factory\JobFactory;
+use BackTo\Framework\Queue\QueueDispatcher;
+use BackTo\Framework\Queue\QueueRegistry;
+use PHPUnit\Framework\TestCase;
+
+class QueueDispatcherTest extends TestCase
+{
+    private QueueRepositoryInterface $repository;
+    private QueueRegistry $registry;
+    private JobFactory $factory;
+    private QueueDispatcher $dispatcher;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createMock(QueueRepositoryInterface::class);
+        $this->registry = new QueueRegistry();
+        $this->factory = new JobFactory();
+
+        $this->dispatcher = new QueueDispatcher(
+            $this->repository,
+            $this->registry,
+            $this->factory
+        );
+    }
+
+    public function testDispatchEnqueuesJobAndReturnsId(): void
+    {
+        $this->repository->expects($this->once())
+            ->method('enqueue')
+            ->with($this->callback(function (Job $job): bool {
+                return $job->getKey() === 'send_email'
+                    && $job->getPayload() === ['to' => 'user@example.com']
+                    && $job->getGroup() === 'emails';
+            }))
+            ->willReturn(42);
+
+        $id = $this->dispatcher->dispatch('send_email', ['to' => 'user@example.com'], 0, 'emails');
+
+        $this->assertSame(42, $id);
+    }
+
+    public function testDispatchUsesHandlerMaxRetriesWhenRegistered(): void
+    {
+        $handler = $this->createMock(JobInterface::class);
+        $handler->method('getKey')->willReturn('send_email');
+        $handler->method('getLabel')->willReturn('Send Email');
+        $handler->method('getGroup')->willReturn('default');
+        $handler->method('getMaxRetries')->willReturn(7);
+
+        $this->registry->add($handler);
+
+        $this->repository->expects($this->once())
+            ->method('enqueue')
+            ->with($this->callback(function (Job $job): bool {
+                return $job->getMaxRetries() === 7;
+            }))
+            ->willReturn(1);
+
+        $this->dispatcher->dispatch('send_email');
+    }
+
+    public function testDispatchUsesDefaultMaxRetriesWhenNoHandler(): void
+    {
+        $this->repository->expects($this->once())
+            ->method('enqueue')
+            ->with($this->callback(function (Job $job): bool {
+                return $job->getMaxRetries() === 3;
+            }))
+            ->willReturn(1);
+
+        $this->dispatcher->dispatch('unregistered_job');
+    }
+
+    public function testDispatchWithDelay(): void
+    {
+        $before = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        $this->repository->expects($this->once())
+            ->method('enqueue')
+            ->with($this->callback(function (Job $job) use ($before): bool {
+                $expected = $before->modify('+60 seconds');
+
+                return $job->getScheduledAt() !== null
+                    && $job->getScheduledAt() >= $expected;
+            }))
+            ->willReturn(1);
+
+        $this->dispatcher->dispatch('send_email', [], 60);
+    }
+
+    public function testScheduleCreatesRecurringJob(): void
+    {
+        $this->repository->expects($this->once())
+            ->method('enqueue')
+            ->with($this->callback(function (Job $job): bool {
+                return $job->getKey() === 'cleanup_logs'
+                    && $job->getIntervalSeconds() === 3600
+                    && $job->isRecurring();
+            }))
+            ->willReturn(10);
+
+        $id = $this->dispatcher->schedule('cleanup_logs', 3600);
+
+        $this->assertSame(10, $id);
+    }
+
+    public function testScheduleUsesHandlerMaxRetries(): void
+    {
+        $handler = $this->createMock(JobInterface::class);
+        $handler->method('getKey')->willReturn('sync_data');
+        $handler->method('getLabel')->willReturn('Sync Data');
+        $handler->method('getGroup')->willReturn('default');
+        $handler->method('getMaxRetries')->willReturn(10);
+
+        $this->registry->add($handler);
+
+        $this->repository->expects($this->once())
+            ->method('enqueue')
+            ->with($this->callback(function (Job $job): bool {
+                return $job->getMaxRetries() === 10;
+            }))
+            ->willReturn(1);
+
+        $this->dispatcher->schedule('sync_data', 600);
+    }
+
+    public function testScheduleWithPayloadAndGroup(): void
+    {
+        $payload = ['source' => 'api', 'limit' => 100];
+
+        $this->repository->expects($this->once())
+            ->method('enqueue')
+            ->with($this->callback(function (Job $job) use ($payload): bool {
+                return $job->getPayload() === $payload
+                    && $job->getGroup() === 'sync';
+            }))
+            ->willReturn(5);
+
+        $this->dispatcher->schedule('import_data', 1800, $payload, 'sync');
+    }
+}

--- a/src/Queue/Tests/QueueDispatcherTest.php
+++ b/src/Queue/Tests/QueueDispatcherTest.php
@@ -147,4 +147,55 @@ class QueueDispatcherTest extends TestCase
 
         $this->dispatcher->schedule('import_data', 1800, $payload, 'sync');
     }
+
+    public function testDispatchUniqueSkipsWhenDuplicateExists(): void
+    {
+        $payload = ['sku' => 'ABC123'];
+        $payloadHash = \md5(\json_encode($payload, \JSON_THROW_ON_ERROR));
+
+        $this->repository->expects($this->once())
+            ->method('hasPendingDuplicate')
+            ->with('sync_inventory', $payloadHash)
+            ->willReturn(true);
+
+        $this->repository->expects($this->never())->method('enqueue');
+
+        $result = $this->dispatcher->dispatchUnique('sync_inventory', $payload);
+
+        $this->assertNull($result);
+    }
+
+    public function testDispatchUniqueDispatchesWhenNoDuplicate(): void
+    {
+        $payload = ['sku' => 'ABC123'];
+        $payloadHash = \md5(\json_encode($payload, \JSON_THROW_ON_ERROR));
+
+        $this->repository->expects($this->once())
+            ->method('hasPendingDuplicate')
+            ->with('sync_inventory', $payloadHash)
+            ->willReturn(false);
+
+        $this->repository->expects($this->once())
+            ->method('enqueue')
+            ->willReturn(42);
+
+        $result = $this->dispatcher->dispatchUnique('sync_inventory', $payload);
+
+        $this->assertSame(42, $result);
+    }
+
+    public function testDispatchedJobContainsPayloadHash(): void
+    {
+        $payload = ['to' => 'user@example.com'];
+        $expectedHash = \md5(\json_encode($payload, \JSON_THROW_ON_ERROR));
+
+        $this->repository->expects($this->once())
+            ->method('enqueue')
+            ->with($this->callback(function (Job $job) use ($expectedHash): bool {
+                return $job->getPayloadHash() === $expectedHash;
+            }))
+            ->willReturn(1);
+
+        $this->dispatcher->dispatch('send_email', $payload);
+    }
 }

--- a/src/Queue/Tests/QueueRegistryTest.php
+++ b/src/Queue/Tests/QueueRegistryTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Tests;
+
+use BackTo\Framework\Contracts\RegistryInterface;
+use BackTo\Framework\Queue\Contracts\JobInterface;
+use BackTo\Framework\Queue\QueueRegistry;
+use PHPUnit\Framework\TestCase;
+
+class SendEmailJob implements JobInterface
+{
+    public function getKey(): string
+    {
+        return 'send_email';
+    }
+
+    public function getLabel(): string
+    {
+        return 'Send Email';
+    }
+
+    public function getGroup(): string
+    {
+        return 'emails';
+    }
+
+    public function getMaxRetries(): int
+    {
+        return 3;
+    }
+
+    public function handle(array $payload): void
+    {
+    }
+}
+
+class ProcessImageJob implements JobInterface
+{
+    public function getKey(): string
+    {
+        return 'process_image';
+    }
+
+    public function getLabel(): string
+    {
+        return 'Process Image';
+    }
+
+    public function getGroup(): string
+    {
+        return 'media';
+    }
+
+    public function getMaxRetries(): int
+    {
+        return 5;
+    }
+
+    public function handle(array $payload): void
+    {
+    }
+}
+
+class QueueRegistryTest extends TestCase
+{
+    public function testRegistryShouldImplementRegistryInterface(): void
+    {
+        $registry = new QueueRegistry();
+
+        $this->assertInstanceOf(RegistryInterface::class, $registry);
+    }
+
+    public function testEmptyRegistry(): void
+    {
+        $registry = new QueueRegistry();
+
+        $this->assertCount(0, $registry->getJobs());
+    }
+
+    public function testAddingJobs(): void
+    {
+        $registry = new QueueRegistry();
+        $registry->add(new SendEmailJob());
+        $registry->add(new ProcessImageJob());
+
+        $this->assertCount(2, $registry->getJobs());
+    }
+
+    public function testGetJobByKey(): void
+    {
+        $registry = new QueueRegistry();
+        $job = new SendEmailJob();
+        $registry->add($job);
+
+        $found = $registry->get('send_email');
+
+        $this->assertNotNull($found);
+        $this->assertSame('send_email', $found->getKey());
+    }
+
+    public function testGetNonExistentJobReturnsNull(): void
+    {
+        $registry = new QueueRegistry();
+
+        $this->assertNull($registry->get('non_existent'));
+    }
+
+    public function testAddingDuplicateKeyOverwrites(): void
+    {
+        $registry = new QueueRegistry();
+        $registry->add(new SendEmailJob());
+        $registry->add(new SendEmailJob());
+
+        $this->assertCount(1, $registry->getJobs());
+    }
+}

--- a/src/Queue/Tests/QueueWorkerTest.php
+++ b/src/Queue/Tests/QueueWorkerTest.php
@@ -164,6 +164,26 @@ class QueueWorkerTest extends TestCase
         $this->assertSame(3, $processed);
     }
 
+    public function testProcessQueueClampsExcessiveBatchSize(): void
+    {
+        $this->repository->method('claimNextPending')->willReturn(null);
+
+        // Should not crash or loop 10000 times — capped at 100.
+        $processed = $this->worker->processQueue('default', 10000);
+
+        $this->assertSame(0, $processed);
+    }
+
+    public function testProcessQueueClampsZeroBatchSize(): void
+    {
+        $this->repository->method('claimNextPending')->willReturn(null);
+
+        // Zero should be clamped to 1.
+        $processed = $this->worker->processQueue('default', 0);
+
+        $this->assertSame(0, $processed);
+    }
+
     public function testProcessQueueReschedulesRecurringJob(): void
     {
         $handler = $this->createMock(JobInterface::class);

--- a/src/Queue/Tests/QueueWorkerTest.php
+++ b/src/Queue/Tests/QueueWorkerTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Tests;
+
+use BackTo\Framework\Queue\Contracts\JobInterface;
+use BackTo\Framework\Queue\Contracts\QueueRepositoryInterface;
+use BackTo\Framework\Queue\Entity\Job;
+use BackTo\Framework\Queue\Entity\JobStatus;
+use BackTo\Framework\Queue\Factory\JobFactory;
+use BackTo\Framework\Queue\QueueRegistry;
+use BackTo\Framework\Queue\QueueWorker;
+use PHPUnit\Framework\TestCase;
+
+class QueueWorkerTest extends TestCase
+{
+    private QueueRepositoryInterface $repository;
+    private QueueRegistry $registry;
+    private QueueWorker $worker;
+    private JobFactory $factory;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createMock(QueueRepositoryInterface::class);
+        $this->registry = new QueueRegistry();
+        $this->factory = new JobFactory();
+
+        $this->worker = new QueueWorker(
+            $this->repository,
+            $this->registry,
+            $this->factory
+        );
+    }
+
+    public function testProcessQueueReturnsZeroWhenEmpty(): void
+    {
+        $this->repository->method('claimNextPending')->willReturn(null);
+
+        $processed = $this->worker->processQueue();
+
+        $this->assertSame(0, $processed);
+    }
+
+    public function testProcessQueueExecutesHandler(): void
+    {
+        $handled = false;
+
+        $handler = $this->createMock(JobInterface::class);
+        $handler->method('getKey')->willReturn('test_job');
+        $handler->method('getLabel')->willReturn('Test Job');
+        $handler->method('getGroup')->willReturn('default');
+        $handler->method('getMaxRetries')->willReturn(3);
+        $handler->method('handle')->willReturnCallback(function () use (&$handled) {
+            $handled = true;
+        });
+
+        $this->registry->add($handler);
+
+        $job = new Job();
+        $job->setId(1)->setKey('test_job')->setStatus(JobStatus::Running);
+
+        $this->repository->method('claimNextPending')
+            ->willReturnOnConsecutiveCalls($job, null);
+
+        $this->repository->expects($this->once())->method('markCompleted')->with(1);
+
+        $processed = $this->worker->processQueue();
+
+        $this->assertSame(1, $processed);
+        $this->assertTrue($handled);
+    }
+
+    public function testProcessQueueHandlesFailure(): void
+    {
+        $handler = $this->createMock(JobInterface::class);
+        $handler->method('getKey')->willReturn('failing_job');
+        $handler->method('getLabel')->willReturn('Failing Job');
+        $handler->method('getGroup')->willReturn('default');
+        $handler->method('getMaxRetries')->willReturn(3);
+        $handler->method('handle')->willThrowException(new \RuntimeException('Something went wrong'));
+
+        $this->registry->add($handler);
+
+        $job = new Job();
+        $job->setId(1)->setKey('failing_job')->setStatus(JobStatus::Running)->setMaxRetries(3)->setAttempts(0);
+
+        $retryJob = new Job();
+        $retryJob->setId(1)->setKey('failing_job')->setStatus(JobStatus::Failed)->setMaxRetries(3)->setAttempts(1);
+
+        $this->repository->method('claimNextPending')
+            ->willReturnOnConsecutiveCalls($job, null);
+
+        $this->repository->expects($this->once())->method('markFailed')->with(1, 'Something went wrong');
+        $this->repository->method('find')->with(1)->willReturn($retryJob);
+        $this->repository->expects($this->once())->method('release')->with(1);
+
+        $this->worker->processQueue();
+    }
+
+    public function testProcessQueueNoRetryWhenMaxReached(): void
+    {
+        $handler = $this->createMock(JobInterface::class);
+        $handler->method('getKey')->willReturn('failing_job');
+        $handler->method('getLabel')->willReturn('Failing Job');
+        $handler->method('getGroup')->willReturn('default');
+        $handler->method('getMaxRetries')->willReturn(3);
+        $handler->method('handle')->willThrowException(new \RuntimeException('Final failure'));
+
+        $this->registry->add($handler);
+
+        $job = new Job();
+        $job->setId(1)->setKey('failing_job')->setStatus(JobStatus::Running)->setMaxRetries(3)->setAttempts(2);
+
+        $exhaustedJob = new Job();
+        $exhaustedJob->setId(1)->setKey('failing_job')->setStatus(JobStatus::Failed)->setMaxRetries(3)->setAttempts(3);
+
+        $this->repository->method('claimNextPending')
+            ->willReturnOnConsecutiveCalls($job, null);
+
+        $this->repository->method('find')->with(1)->willReturn($exhaustedJob);
+        $this->repository->expects($this->never())->method('release');
+
+        $this->worker->processQueue();
+    }
+
+    public function testProcessQueueMarksFailedWhenNoHandler(): void
+    {
+        $job = new Job();
+        $job->setId(1)->setKey('unknown_job')->setStatus(JobStatus::Running);
+
+        $this->repository->method('claimNextPending')
+            ->willReturnOnConsecutiveCalls($job, null);
+
+        $this->repository->expects($this->once())->method('markFailed')
+            ->with(1, 'No handler registered for job key: unknown_job');
+
+        $this->worker->processQueue();
+    }
+
+    public function testProcessQueueRespectsBatchSize(): void
+    {
+        $handler = $this->createMock(JobInterface::class);
+        $handler->method('getKey')->willReturn('batch_job');
+        $handler->method('getLabel')->willReturn('Batch Job');
+        $handler->method('getGroup')->willReturn('default');
+        $handler->method('getMaxRetries')->willReturn(3);
+
+        $this->registry->add($handler);
+
+        $jobs = [];
+        for ($i = 1; $i <= 5; $i++) {
+            $job = new Job();
+            $job->setId($i)->setKey('batch_job')->setStatus(JobStatus::Running);
+            $jobs[] = $job;
+        }
+        $jobs[] = null;
+
+        $this->repository->method('claimNextPending')
+            ->willReturnOnConsecutiveCalls(...$jobs);
+
+        $processed = $this->worker->processQueue('default', 3);
+
+        $this->assertSame(3, $processed);
+    }
+}

--- a/src/Queue/Tests/QueueWorkerTest.php
+++ b/src/Queue/Tests/QueueWorkerTest.php
@@ -163,4 +163,178 @@ class QueueWorkerTest extends TestCase
 
         $this->assertSame(3, $processed);
     }
+
+    public function testProcessQueueReschedulesRecurringJob(): void
+    {
+        $handler = $this->createMock(JobInterface::class);
+        $handler->method('getKey')->willReturn('recurring_job');
+        $handler->method('getLabel')->willReturn('Recurring Job');
+        $handler->method('getGroup')->willReturn('default');
+        $handler->method('getMaxRetries')->willReturn(3);
+
+        $this->registry->add($handler);
+
+        $job = new Job();
+        $job->setId(1)
+            ->setKey('recurring_job')
+            ->setGroup('sync')
+            ->setPayload(['source' => 'api'])
+            ->setStatus(JobStatus::Running)
+            ->setMaxRetries(3)
+            ->setIntervalSeconds(3600);
+
+        $this->repository->method('claimNextPending')
+            ->willReturnOnConsecutiveCalls($job, null);
+
+        $this->repository->expects($this->once())->method('markCompleted')->with(1);
+
+        // Should enqueue a new job for the next recurrence.
+        $this->repository->expects($this->once())
+            ->method('enqueue')
+            ->with($this->callback(function (Job $newJob): bool {
+                return $newJob->getKey() === 'recurring_job'
+                    && $newJob->getGroup() === 'sync'
+                    && $newJob->getPayload() === ['source' => 'api']
+                    && $newJob->getIntervalSeconds() === 3600
+                    && $newJob->isRecurring();
+            }));
+
+        $this->worker->processQueue();
+    }
+
+    public function testProcessQueueDoesNotRescheduleNonRecurringJob(): void
+    {
+        $handler = $this->createMock(JobInterface::class);
+        $handler->method('getKey')->willReturn('one_off_job');
+        $handler->method('getLabel')->willReturn('One Off Job');
+        $handler->method('getGroup')->willReturn('default');
+        $handler->method('getMaxRetries')->willReturn(3);
+
+        $this->registry->add($handler);
+
+        $job = new Job();
+        $job->setId(1)
+            ->setKey('one_off_job')
+            ->setStatus(JobStatus::Running)
+            ->setIntervalSeconds(0);
+
+        $this->repository->method('claimNextPending')
+            ->willReturnOnConsecutiveCalls($job, null);
+
+        $this->repository->expects($this->once())->method('markCompleted')->with(1);
+        $this->repository->expects($this->never())->method('enqueue');
+
+        $this->worker->processQueue();
+    }
+
+    public function testProcessQueueDoesNotRescheduleFailedRecurringJob(): void
+    {
+        $handler = $this->createMock(JobInterface::class);
+        $handler->method('getKey')->willReturn('recurring_fail');
+        $handler->method('getLabel')->willReturn('Recurring Fail');
+        $handler->method('getGroup')->willReturn('default');
+        $handler->method('getMaxRetries')->willReturn(1);
+        $handler->method('handle')->willThrowException(new \RuntimeException('Crash'));
+
+        $this->registry->add($handler);
+
+        $job = new Job();
+        $job->setId(1)
+            ->setKey('recurring_fail')
+            ->setStatus(JobStatus::Running)
+            ->setMaxRetries(1)
+            ->setAttempts(0)
+            ->setIntervalSeconds(600);
+
+        $exhaustedJob = new Job();
+        $exhaustedJob->setId(1)
+            ->setKey('recurring_fail')
+            ->setStatus(JobStatus::Failed)
+            ->setMaxRetries(1)
+            ->setAttempts(1)
+            ->setIntervalSeconds(600);
+
+        $this->repository->method('claimNextPending')
+            ->willReturnOnConsecutiveCalls($job, null);
+
+        $this->repository->method('find')->with(1)->willReturn($exhaustedJob);
+
+        // Should not enqueue a rescheduled job since it failed.
+        $this->repository->expects($this->never())->method('enqueue');
+        $this->repository->expects($this->once())->method('markFailed');
+
+        $this->worker->processQueue();
+    }
+
+    public function testProcessQueuePassesPayloadToHandler(): void
+    {
+        $receivedPayload = null;
+
+        $handler = $this->createMock(JobInterface::class);
+        $handler->method('getKey')->willReturn('payload_job');
+        $handler->method('getLabel')->willReturn('Payload Job');
+        $handler->method('getGroup')->willReturn('default');
+        $handler->method('getMaxRetries')->willReturn(3);
+        $handler->method('handle')->willReturnCallback(function (array $payload) use (&$receivedPayload) {
+            $receivedPayload = $payload;
+        });
+
+        $this->registry->add($handler);
+
+        $expectedPayload = ['email' => 'test@example.com', 'template' => 'welcome'];
+
+        $job = new Job();
+        $job->setId(1)->setKey('payload_job')->setStatus(JobStatus::Running)->setPayload($expectedPayload);
+
+        $this->repository->method('claimNextPending')
+            ->willReturnOnConsecutiveCalls($job, null);
+
+        $this->worker->processQueue();
+
+        $this->assertSame($expectedPayload, $receivedPayload);
+    }
+
+    public function testProcessQueueWithSpecificGroup(): void
+    {
+        $handler = $this->createMock(JobInterface::class);
+        $handler->method('getKey')->willReturn('group_job');
+        $handler->method('getLabel')->willReturn('Group Job');
+        $handler->method('getGroup')->willReturn('emails');
+        $handler->method('getMaxRetries')->willReturn(3);
+
+        $this->registry->add($handler);
+
+        $this->repository->expects($this->once())
+            ->method('claimNextPending')
+            ->with('emails')
+            ->willReturn(null);
+
+        $this->worker->processQueue('emails');
+    }
+
+    public function testProcessQueueHandlesFailureWhenFindReturnsNull(): void
+    {
+        $handler = $this->createMock(JobInterface::class);
+        $handler->method('getKey')->willReturn('vanishing_job');
+        $handler->method('getLabel')->willReturn('Vanishing Job');
+        $handler->method('getGroup')->willReturn('default');
+        $handler->method('getMaxRetries')->willReturn(3);
+        $handler->method('handle')->willThrowException(new \RuntimeException('Error'));
+
+        $this->registry->add($handler);
+
+        $job = new Job();
+        $job->setId(99)->setKey('vanishing_job')->setStatus(JobStatus::Running);
+
+        $this->repository->method('claimNextPending')
+            ->willReturnOnConsecutiveCalls($job, null);
+
+        $this->repository->expects($this->once())->method('markFailed');
+        // find returns null (job deleted between markFailed and find).
+        $this->repository->method('find')->with(99)->willReturn(null);
+        // Should not call release since we can't find the job.
+        $this->repository->expects($this->never())->method('release');
+
+        $this->worker->processQueue();
+    }
 }

--- a/src/Queue/Tests/RegisterQueueTest.php
+++ b/src/Queue/Tests/RegisterQueueTest.php
@@ -95,6 +95,13 @@ class RegisterQueueTest extends TestCase
         $this->registerQueue->activate();
     }
 
+    public function testUninstallDropsTableAndCleansTransient(): void
+    {
+        $this->repository->expects($this->once())->method('dropTable');
+
+        $this->registerQueue->uninstall();
+    }
+
     public function testRegisterCronScheduleAddsEveryMinute(): void
     {
         $schedules = $this->registerQueue->registerCronSchedule([]);

--- a/src/Queue/Tests/RegisterQueueTest.php
+++ b/src/Queue/Tests/RegisterQueueTest.php
@@ -24,6 +24,11 @@ class RegisterQueueTest extends TestCase
     private HookDispatcherInterface $hookDispatcher;
     private RegisterQueue $registerQueue;
 
+    public static function setUpBeforeClass(): void
+    {
+        require_once __DIR__ . '/wp_stubs.php';
+    }
+
     protected function setUp(): void
     {
         $this->repository = $this->createMock(QueueRepositoryInterface::class);
@@ -114,52 +119,6 @@ class RegisterQueueTest extends TestCase
         $this->assertSame('Custom Every Minute', $schedules['every_minute']['display']);
     }
 
-    public function testProcessAllGroupsProcessesDefaultGroup(): void
-    {
-        // With no registered jobs, only 'default' group should be processed.
-        // Worker will call claimNextPending('default').
-        $this->repository->expects($this->once())
-            ->method('claimNextPending')
-            ->with('default')
-            ->willReturn(null);
-
-        $this->registerQueue->processAllGroups();
-    }
-
-    public function testProcessAllGroupsProcessesMultipleGroups(): void
-    {
-        $emailJob = $this->createMock(JobInterface::class);
-        $emailJob->method('getKey')->willReturn('send_email');
-        $emailJob->method('getLabel')->willReturn('Send Email');
-        $emailJob->method('getGroup')->willReturn('emails');
-        $emailJob->method('getMaxRetries')->willReturn(3);
-
-        $mediaJob = $this->createMock(JobInterface::class);
-        $mediaJob->method('getKey')->willReturn('process_image');
-        $mediaJob->method('getLabel')->willReturn('Process Image');
-        $mediaJob->method('getGroup')->willReturn('media');
-        $mediaJob->method('getMaxRetries')->willReturn(5);
-
-        $this->registry->add($emailJob);
-        $this->registry->add($mediaJob);
-
-        $processedGroups = [];
-
-        $this->repository->method('claimNextPending')
-            ->willReturnCallback(function (string $group) use (&$processedGroups) {
-                $processedGroups[] = $group;
-
-                return null;
-            });
-
-        $this->registerQueue->processAllGroups();
-
-        $this->assertContains('default', $processedGroups);
-        $this->assertContains('emails', $processedGroups);
-        $this->assertContains('media', $processedGroups);
-        $this->assertCount(3, $processedGroups);
-    }
-
     public function testRescueStuckJobsDelegatesToRepository(): void
     {
         $this->repository->expects($this->once())
@@ -169,13 +128,17 @@ class RegisterQueueTest extends TestCase
         $this->registerQueue->rescueStuckJobs();
     }
 
-    public function testCleanupCompletedJobsDelegatesToRepository(): void
+    public function testCleanupJobsDelegatesToRepository(): void
     {
         $this->repository->expects($this->once())
             ->method('cleanup')
             ->with(86400);
 
-        $this->registerQueue->cleanupCompletedJobs();
+        $this->repository->expects($this->once())
+            ->method('cleanupFailed')
+            ->with(604800);
+
+        $this->registerQueue->cleanupJobs();
     }
 
     public function testProcessAllGroupsDeduplicatesGroups(): void
@@ -195,6 +158,8 @@ class RegisterQueueTest extends TestCase
         $this->registry->add($job1);
         $this->registry->add($job2);
 
+        $this->repository->method('getActiveGroups')->willReturn([]);
+
         $processedGroups = [];
 
         $this->repository->method('claimNextPending')
@@ -206,8 +171,72 @@ class RegisterQueueTest extends TestCase
 
         $this->registerQueue->processAllGroups();
 
-        // Should only process 'default' once, not twice.
         $this->assertCount(1, $processedGroups);
         $this->assertSame(['default'], $processedGroups);
+    }
+
+    public function testProcessAllGroupsMergesDbGroups(): void
+    {
+        $emailJob = $this->createMock(JobInterface::class);
+        $emailJob->method('getKey')->willReturn('send_email');
+        $emailJob->method('getLabel')->willReturn('Send Email');
+        $emailJob->method('getGroup')->willReturn('emails');
+        $emailJob->method('getMaxRetries')->willReturn(3);
+
+        $this->registry->add($emailJob);
+
+        $this->repository->method('getActiveGroups')->willReturn(['emails', 'orphan_group']);
+
+        $processedGroups = [];
+
+        $this->repository->method('claimNextPending')
+            ->willReturnCallback(function (string $group) use (&$processedGroups) {
+                $processedGroups[] = $group;
+
+                return null;
+            });
+
+        $this->registerQueue->processAllGroups();
+
+        $this->assertContains('default', $processedGroups);
+        $this->assertContains('emails', $processedGroups);
+        $this->assertContains('orphan_group', $processedGroups);
+        $this->assertCount(3, $processedGroups);
+    }
+
+    public function testProcessAllGroupsProcessesMultipleGroups(): void
+    {
+        $emailJob = $this->createMock(JobInterface::class);
+        $emailJob->method('getKey')->willReturn('send_email');
+        $emailJob->method('getLabel')->willReturn('Send Email');
+        $emailJob->method('getGroup')->willReturn('emails');
+        $emailJob->method('getMaxRetries')->willReturn(3);
+
+        $mediaJob = $this->createMock(JobInterface::class);
+        $mediaJob->method('getKey')->willReturn('process_image');
+        $mediaJob->method('getLabel')->willReturn('Process Image');
+        $mediaJob->method('getGroup')->willReturn('media');
+        $mediaJob->method('getMaxRetries')->willReturn(5);
+
+        $this->registry->add($emailJob);
+        $this->registry->add($mediaJob);
+
+        $this->repository->method('getActiveGroups')->willReturn([]);
+
+        $processedGroups = [];
+
+        $this->repository->method('claimNextPending')
+            ->willReturnCallback(function (string $group) use (&$processedGroups) {
+                $processedGroups[] = $group;
+
+                return null;
+            });
+
+        $this->registerQueue->processAllGroups();
+
+        $this->assertContains('default', $processedGroups);
+        $this->assertContains('emails', $processedGroups);
+        $this->assertContains('media', $processedGroups);
+        $this->assertCount(3, $processedGroups);
     }
 }

--- a/src/Queue/Tests/RegisterQueueTest.php
+++ b/src/Queue/Tests/RegisterQueueTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BackTo\Framework\Queue\Tests;
+
+use BackTo\Framework\Contracts\ActivationHooks;
+use BackTo\Framework\Contracts\DeactivationHooks;
+use BackTo\Framework\Contracts\HookDispatcherInterface;
+use BackTo\Framework\Contracts\Hooks;
+use BackTo\Framework\Queue\Contracts\JobInterface;
+use BackTo\Framework\Queue\Contracts\QueueRepositoryInterface;
+use BackTo\Framework\Queue\Factory\JobFactory;
+use BackTo\Framework\Queue\QueueRegistry;
+use BackTo\Framework\Queue\QueueWorker;
+use BackTo\Framework\Queue\RegisterQueue;
+use PHPUnit\Framework\TestCase;
+
+class RegisterQueueTest extends TestCase
+{
+    private QueueRepositoryInterface $repository;
+    private QueueWorker $worker;
+    private QueueRegistry $registry;
+    private HookDispatcherInterface $hookDispatcher;
+    private RegisterQueue $registerQueue;
+
+    protected function setUp(): void
+    {
+        $this->repository = $this->createMock(QueueRepositoryInterface::class);
+        $this->registry = new QueueRegistry();
+        $this->hookDispatcher = $this->createMock(HookDispatcherInterface::class);
+
+        $this->worker = new QueueWorker(
+            $this->repository,
+            $this->registry,
+            new JobFactory()
+        );
+
+        $this->registerQueue = new RegisterQueue(
+            $this->repository,
+            $this->worker,
+            $this->registry,
+            $this->hookDispatcher
+        );
+    }
+
+    public function testImplementsHooksInterface(): void
+    {
+        $this->assertInstanceOf(Hooks::class, $this->registerQueue);
+    }
+
+    public function testImplementsActivationHooksInterface(): void
+    {
+        $this->assertInstanceOf(ActivationHooks::class, $this->registerQueue);
+    }
+
+    public function testImplementsDeactivationHooksInterface(): void
+    {
+        $this->assertInstanceOf(DeactivationHooks::class, $this->registerQueue);
+    }
+
+    public function testHooksRegistersExpectedActions(): void
+    {
+        $registeredActions = [];
+        $registeredFilters = [];
+
+        $this->hookDispatcher->method('addAction')
+            ->willReturnCallback(function (string $hook) use (&$registeredActions): void {
+                $registeredActions[] = $hook;
+            });
+
+        $this->hookDispatcher->method('addFilter')
+            ->willReturnCallback(function (string $hook) use (&$registeredFilters): void {
+                $registeredFilters[] = $hook;
+            });
+
+        $this->registerQueue->hooks();
+
+        $this->assertContains('init', $registeredActions);
+        $this->assertContains('backto_queue_process', $registeredActions);
+        $this->assertContains('backto_queue_rescue', $registeredActions);
+        $this->assertContains('backto_queue_cleanup', $registeredActions);
+        $this->assertContains('cron_schedules', $registeredFilters);
+    }
+
+    public function testActivateCreatesTable(): void
+    {
+        $this->repository->expects($this->once())->method('createTable');
+
+        $this->registerQueue->activate();
+    }
+
+    public function testRegisterCronScheduleAddsEveryMinute(): void
+    {
+        $schedules = $this->registerQueue->registerCronSchedule([]);
+
+        $this->assertArrayHasKey('every_minute', $schedules);
+        $this->assertSame(60, $schedules['every_minute']['interval']);
+        $this->assertSame('Every Minute', $schedules['every_minute']['display']);
+    }
+
+    public function testRegisterCronScheduleDoesNotOverwriteExisting(): void
+    {
+        $existing = [
+            'every_minute' => [
+                'interval' => 30,
+                'display' => 'Custom Every Minute',
+            ],
+        ];
+
+        $schedules = $this->registerQueue->registerCronSchedule($existing);
+
+        $this->assertSame(30, $schedules['every_minute']['interval']);
+        $this->assertSame('Custom Every Minute', $schedules['every_minute']['display']);
+    }
+
+    public function testProcessAllGroupsProcessesDefaultGroup(): void
+    {
+        // With no registered jobs, only 'default' group should be processed.
+        // Worker will call claimNextPending('default').
+        $this->repository->expects($this->once())
+            ->method('claimNextPending')
+            ->with('default')
+            ->willReturn(null);
+
+        $this->registerQueue->processAllGroups();
+    }
+
+    public function testProcessAllGroupsProcessesMultipleGroups(): void
+    {
+        $emailJob = $this->createMock(JobInterface::class);
+        $emailJob->method('getKey')->willReturn('send_email');
+        $emailJob->method('getLabel')->willReturn('Send Email');
+        $emailJob->method('getGroup')->willReturn('emails');
+        $emailJob->method('getMaxRetries')->willReturn(3);
+
+        $mediaJob = $this->createMock(JobInterface::class);
+        $mediaJob->method('getKey')->willReturn('process_image');
+        $mediaJob->method('getLabel')->willReturn('Process Image');
+        $mediaJob->method('getGroup')->willReturn('media');
+        $mediaJob->method('getMaxRetries')->willReturn(5);
+
+        $this->registry->add($emailJob);
+        $this->registry->add($mediaJob);
+
+        $processedGroups = [];
+
+        $this->repository->method('claimNextPending')
+            ->willReturnCallback(function (string $group) use (&$processedGroups) {
+                $processedGroups[] = $group;
+
+                return null;
+            });
+
+        $this->registerQueue->processAllGroups();
+
+        $this->assertContains('default', $processedGroups);
+        $this->assertContains('emails', $processedGroups);
+        $this->assertContains('media', $processedGroups);
+        $this->assertCount(3, $processedGroups);
+    }
+
+    public function testRescueStuckJobsDelegatesToRepository(): void
+    {
+        $this->repository->expects($this->once())
+            ->method('rescueStuck')
+            ->with(300);
+
+        $this->registerQueue->rescueStuckJobs();
+    }
+
+    public function testCleanupCompletedJobsDelegatesToRepository(): void
+    {
+        $this->repository->expects($this->once())
+            ->method('cleanup')
+            ->with(86400);
+
+        $this->registerQueue->cleanupCompletedJobs();
+    }
+
+    public function testProcessAllGroupsDeduplicatesGroups(): void
+    {
+        $job1 = $this->createMock(JobInterface::class);
+        $job1->method('getKey')->willReturn('job_a');
+        $job1->method('getLabel')->willReturn('Job A');
+        $job1->method('getGroup')->willReturn('default');
+        $job1->method('getMaxRetries')->willReturn(3);
+
+        $job2 = $this->createMock(JobInterface::class);
+        $job2->method('getKey')->willReturn('job_b');
+        $job2->method('getLabel')->willReturn('Job B');
+        $job2->method('getGroup')->willReturn('default');
+        $job2->method('getMaxRetries')->willReturn(3);
+
+        $this->registry->add($job1);
+        $this->registry->add($job2);
+
+        $processedGroups = [];
+
+        $this->repository->method('claimNextPending')
+            ->willReturnCallback(function (string $group) use (&$processedGroups) {
+                $processedGroups[] = $group;
+
+                return null;
+            });
+
+        $this->registerQueue->processAllGroups();
+
+        // Should only process 'default' once, not twice.
+        $this->assertCount(1, $processedGroups);
+        $this->assertSame(['default'], $processedGroups);
+    }
+}

--- a/src/Queue/Tests/wp_stubs.php
+++ b/src/Queue/Tests/wp_stubs.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * WordPress function stubs for unit testing outside of WordPress.
+ * These are only defined if the real functions don't exist.
+ */
+
+if (!\function_exists('wp_next_scheduled')) {
+    function wp_next_scheduled(string $hook): bool
+    {
+        return false;
+    }
+}
+
+if (!\function_exists('wp_schedule_event')) {
+    function wp_schedule_event(int $timestamp, string $recurrence, string $hook): void
+    {
+    }
+}
+
+if (!\function_exists('wp_clear_scheduled_hook')) {
+    function wp_clear_scheduled_hook(string $hook): void
+    {
+    }
+}
+
+if (!\function_exists('get_transient')) {
+    function get_transient(string $key): mixed
+    {
+        return false;
+    }
+}
+
+if (!\function_exists('set_transient')) {
+    function set_transient(string $key, mixed $value, int $expiration = 0): bool
+    {
+        return true;
+    }
+}
+
+if (!\function_exists('delete_transient')) {
+    function delete_transient(string $key): bool
+    {
+        return true;
+    }
+}

--- a/src/Queue/composer.json
+++ b/src/Queue/composer.json
@@ -1,0 +1,30 @@
+{
+    "name": "backto/queue",
+    "description": "Async job queue system for the BackTo Framework, similar to Action Scheduler",
+    "type": "library",
+    "license": "proprietary",
+    "authors": [
+        {
+            "name": "Florian Truchot",
+            "email": "florian@truchot.co"
+        }
+    ],
+    "require": {
+        "php": ">=8.2",
+        "backto/contracts": "^1.0",
+        "backto/compose": "^1.0",
+        "backto/exception": "^1.0",
+        "backto/hooks": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "BackTo\\Framework\\Queue\\": ""
+        }
+    },
+    "minimum-stability": "stable",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    }
+}


### PR DESCRIPTION
Introduce a new Queue module inspired by Action Scheduler for WordPress.
Provides job dispatching, cron-based processing, retry logic, recurring
jobs, and stuck job rescue — all following the framework's Clean Architecture
patterns (contracts, entities, factories, infrastructure adapters, DI).

https://claude.ai/code/session_01PZUVQ7xoVUYZNEWaUDP4uJ